### PR TITLE
Add support for a deploy key and ssh connection strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ defaults):
     "spel_amigen6source": "https://github.com/ferricoxide/AMIgen6.git",
     "spel_amiutilsource": "https://github.com/ferricoxide/Lx-GetAMI-Utils.git",
     "spel_awsclisource": "https://s3.amazonaws.com/aws-cli",
+    "spel_deploykey": "",
     "spel_epelrelease": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm",
     "spel_identifier": "",
     "spel_version": "",
@@ -138,9 +139,10 @@ defaults):
 | `atlas_username`     | Username in Hashicorp Atlas                                 |
 | `spel_identifier`    | Project ID to associate to the resulting images             |
 | `spel_version`       | Version to assign to the resulting image(s)                 |
-| `spel_amigen6source` | URL to the git repository for the `AMIGen6` project         |
-| `spel_amiutilsource` | URL to the git repository for the `Lx-GetAMI-Utils` project |
+| `spel_amigen6source` | URI to the git repository for the `AMIGen6` project         |
+| `spel_amiutilsource` | URI to the git repository for the `Lx-GetAMI-Utils` project |
 | `spel_awsclisource`  | URL to the site hosting the file `awscli-bundle.zip`        |
+| `spel_deploykey`     | Deploy key to use if the git repos are private              |
 | `spel_epelrelease`   | URL to the release RPM for the [EPEL][10] repo              |
 
 All other variables in the `packer` template map directly to variables defined

--- a/spel/minimal-linux.json
+++ b/spel/minimal-linux.json
@@ -9,6 +9,7 @@
         "spel_amigen6source": "https://github.com/ferricoxide/AMIgen6.git",
         "spel_amiutilsource": "https://github.com/ferricoxide/Lx-GetAMI-Utils.git",
         "spel_awsclisource": "https://s3.amazonaws.com/aws-cli",
+        "spel_deploykey": "",
         "spel_epelrelease": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm",
         "spel_identifier": "",
         "spel_version": "",
@@ -211,6 +212,7 @@
                 "SPEL_BOOTLABEL=/boot",
                 "SPEL_BUILDDEPS=lvm2 parted yum-utils unzip git",
                 "SPEL_CHROOT=/mnt/ec2-root",
+                "SPEL_DEPLOYKEY={{ user `spel_deploykey` }}",
                 "SPEL_DEVNODE=/dev/xvda",
                 "SPEL_EPELRELEASE={{ user `spel_epelrelease` }}",
                 "SPEL_VGNAME=VolGroup00"

--- a/spel/scripts/amigen6-build.sh
+++ b/spel/scripts/amigen6-build.sh
@@ -11,11 +11,13 @@ BOOTLABEL="${SPEL_BOOTLABEL:-/boot}"
 BUILDDEPS="${SPEL_BUILDDEPS:-lvm2 parted yum-utils unzip git}"
 CHROOT="${SPEL_CHROOT:-/mnt/ec2-root}"
 DEVNODE="${SPEL_DEVNODE:-/dev/xvda}"
+DEPLOYKEY="${SPEL_DEPLOYKEY}"
 EPELRELEASE="${SPEL_EPELRELEASE:-https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm}"
 VGNAME="${SPEL_VGNAME:-VolGroup00}"
 
 ELBUILD="/tmp/el-build"
 AMIUTILS="/tmp/ami-utils"
+SSHIDFILE=""
 
 retry()
 {
@@ -50,11 +52,98 @@ retry()
     return $result
 }  # ----------  end of function retry  ----------
 
+add_ssh_host()
+{
+    # Take a git ssh connection string of the form:
+    #    user@host:account/project.git
+    # and an optional path to a private key, id_file, and add an entry to
+    # ~/.ssh/config:
+    #    host project
+    #      HostName host
+    #      IdentityFile id_file
+    #      User user
+    #
+    # Return a new connection string of the form:
+    #    user@project:account/project.git
+
+    local conn=$1
+    local id_file=$2
+    [[ $# -lt 1 ]] && {
+        echo "Usage $0 <git_connection_string> <ssh_identity_file>"
+        return 1
+    }
+
+    local host=$( echo "${conn}" | awk -F":" '{print $1}' )
+    local project=$( echo "${conn}" | awk -F":" '{print $2}')
+    local conf_host=$( echo "${project}" | awk -F"/" '{print $2}' | \
+        awk -F"." '{print $1}' )
+
+    if [[ "${host}" == *"@"* ]]
+    then
+        local user=$( echo "${host}" | awk -F"@" '{print $1}' )
+        local host=$( echo "${host}" | awk -F"@" '{print $2}' )
+    fi
+
+    # Trust the host
+    ssh-keyscan "${host}" >> ~/.ssh/known_hosts
+
+    # Check for an existing ssh host config and delete it
+    if [[ -e ~/.ssh/config ]]
+    then
+        sed -i "{
+            /^host ${conf_host}$/I,/^host/I{//!d}
+            /^host ${conf_host}$/Id
+        }" ~/.ssh/config
+    fi
+
+    # Add the ssh host config
+    (
+        printf "host %s\n" "${conf_host}"
+        printf "  HostName %s\n" "${host}"
+        if [[ -n "${id_file}" ]]
+        then
+            printf "  IdentityFile %s\n" "${id_file}"
+        fi
+        if [[ -n "${user}" ]]
+        then
+            printf "  User %s\n" "${user}"
+        fi
+    ) >> ~/.ssh/config
+
+    if [[ -n "${user}" ]]
+    then
+        echo "${user}@${conf_host}:${project}"
+    else
+        echo "${conf_host}:${project}"
+    fi
+}  # ----------  end of function add_ssh_host  ----------
+
 set -x
 set -e
 
 echo "Installing build-host dependencies"
 yum -y install ${BUILDDEPS}
+
+if [[ -n "${DEPLOYKEY}" ]]
+then
+    echo "Setting up the deploy key"
+    SSHIDFILE="~/.ssh/spel"
+    rm -f "${SSHIDFILE}"
+    curl -sSkL -o "${SSHIDFILE}" "${DEPLOYKEY}"
+    chmod 600 "${SSHIDFILE}"
+fi
+
+if [[ "${AMIGENSOURCE}" == *":"* ]]
+then
+    echo "Adding ssh config for AMIgen source"
+    AMIGENSOURCE=$(add_ssh_host "${AMIGENSOURCE}" "${SSHIDFILE}")
+fi
+
+if [[ "${AMIUTILSSOURCE}" == *":"* ]]
+then
+    echo "Adding ssh config for AMIutils source"
+    AMIUTILSSOURCE=$(add_ssh_host "${AMIUTILSSOURCE}" "${SSHIDFILE}")
+fi
 
 echo "Cloning source of the AMIGen project"
 git clone "${AMIGENSOURCE}" "${ELBUILD}"


### PR DESCRIPTION
* If the source repos are private, use the `spel_deploykey` variable to specify a deploy key with read privileges to the repos.

* Add support for specifying the URI to the 'source' repos as an ssh connection string, of the form "user@host:team/project.git"