### PR TITLE
Supports the `extras` capability in amigen chrootbuild.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ defaults):
     "spel_customreponame": "",
     "spel_epelrelease": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm",
     "spel_epelrepo": "repo",
+    "spel_extrarpms": "",
     "spel_identifier": "",
     "spel_version": "",
     "iso_url_centos6": "http://mirror.yellowfiber.net/centos/6.8/isos/x86_64/CentOS-6.8-x86_64-minimal.iso",
@@ -133,18 +134,19 @@ defaults):
 }
 ```
 
-| Variable Name         | Description                                                 |
-|-----------------------|-------------------------------------------------------------|
-| `atlas_username`      | Username in Hashicorp Atlas                                 |
-| `spel_identifier`     | Project ID to associate to the resulting images             |
-| `spel_version`        | Version to assign to the resulting image(s)                 |
-| `spel_amigen6source`  | URL to the git repository for the `AMIGen6` project         |
-| `spel_amiutilsource`  | URL to the git repository for the `Lx-GetAMI-Utils` project |
-| `spel_awsclisource`   | URL to the site hosting the file `awscli-bundle.zip`        |
-| `spel_customreporpm`  | URL to a custom release RPM containing base repos           |
-| `spel_customreponame` | Name(s) of the custom yum repos (* or comma-separated)      |
-| `spel_epelrelease`    | URL to the release RPM for the [EPEL][10] repo              |
-| `spel_epelrepo`       | Name of the epel repo (if different than "epel")            |
+| Variable Name         | Description                                                       |
+|-----------------------|-------------------------------------------------------------------|
+| `atlas_username`      | Username in Hashicorp Atlas                                       |
+| `spel_identifier`     | Project ID to associate to the resulting images                   |
+| `spel_version`        | Version to assign to the resulting image(s)                       |
+| `spel_amigen6source`  | URL to the git repository for the `AMIGen6` project               |
+| `spel_amiutilsource`  | URL to the git repository for the `Lx-GetAMI-Utils` project       |
+| `spel_awsclisource`   | URL to the site hosting the file `awscli-bundle.zip`              |
+| `spel_customreporpm`  | URL to a custom release RPM containing base repos                 |
+| `spel_customreponame` | Name(s) of the custom yum repos (* or comma-separated)            |
+| `spel_epelrelease`    | URL to the release RPM for the [EPEL][10] repo                    |
+| `spel_epelrepo`       | Name of the epel repo (if different than "epel")                  |
+| `spel_extrarpms`      | Comma-separated list of extra package/@group names to pass to yum |
 
 All other variables in the `packer` template map directly to variables defined
 in the `packer` docs for the [amazon-ebs builder][11] or the [virtualbox-iso

--- a/spel/minimal-linux.json
+++ b/spel/minimal-linux.json
@@ -13,6 +13,7 @@
         "spel_customreponame": "",
         "spel_epelrelease": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm",
         "spel_epelrepo": "epel",
+        "spel_extrarpms": "",
         "spel_identifier": "",
         "spel_version": "",
         "iso_url_centos6": "http://mirror.yellowfiber.net/centos/6.8/isos/x86_64/CentOS-6.8-x86_64-minimal.iso",
@@ -162,7 +163,7 @@
             "ssh_username": "spel",
             "ssh_port": 122,
             "ssh_pty": true,
-            "ssh_timeout": "15m",
+            "ssh_timeout": "20m",
             "subnet_id": "{{ user `subnet_id` }}",
             "user_data_file": "{{ template_dir }}/userdata/tmpfsroot-el6.cloud",
             "vpc_id": "{{ user `vpc_id` }}"
@@ -227,6 +228,7 @@
                 "SPEL_CUSTOMREPONAME={{ user `spel_customreponame` }}",
                 "SPEL_EPELRELEASE={{ user `spel_epelrelease` }}",
                 "SPEL_EPELREPO={{ user `spel_epelrepo` }}",
+                "SPEL_EXTRARPMS={{ user `spel_extrarpms` }}",
                 "SPEL_VGNAME=VolGroup00"
             ],
             "execute_command": "{{ .Vars }} sudo -E /bin/sh '{{ .Path }}'",

--- a/spel/scripts/amigen6-build.sh
+++ b/spel/scripts/amigen6-build.sh
@@ -15,6 +15,7 @@ CUSTOMREPONAME="${SPEL_CUSTOMREPONAME}"
 DEVNODE="${SPEL_DEVNODE:-/dev/xvda}"
 EPELRELEASE="${SPEL_EPELRELEASE:-https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm}"
 EPELREPO="${SPEL_EPELREPO:-epel}"
+EXTRARPMS="${SPEL_EXTRARPMS}"
 VGNAME="${SPEL_VGNAME:-VolGroup00}"
 
 ELBUILD="/tmp/el-build"
@@ -145,13 +146,22 @@ bash "${ELBUILD}"/MkChrootTree.sh "${DEVNODE}"
 echo "Executing MkTabs.sh"
 bash "${ELBUILD}"/MkTabs.sh
 
-echo "Executing ChrootBuild.sh"
+# Construct the cli option string for extra rpms
+CLIOPT_EXTRARPMS=""
+if [[ -n "${EXTRARPMS}" ]]
+then
+    CLIOPT_EXTRARPMS="-e ${EXTRARPMS}"
+fi
+
+# Construct the cli option string for a custom repo
+CLIOPT_CUSTOMREPO=""
 if [[ -n "${CUSTOMREPORPM}" && -n "${CUSTOMREPONAME}" ]]
 then
-    bash "${ELBUILD}"/ChrootBuild.sh -r "${CUSTOMREPORPM}" -b "${CUSTOMREPONAME}"
-else
-    bash "${ELBUILD}"/ChrootBuild.sh
+    CLIOPT_CUSTOMREPO="-r ${CUSTOMREPORPM} -b ${CUSTOMREPONAME}"
 fi
+
+echo "Executing ChrootBuild.sh"
+bash "${ELBUILD}"/ChrootBuild.sh "${CLIOPT_CUSTOMREPO}" "${CLIOPT_EXTRARPMS}"
 
 # Epel mirrors are maddening; retry 5 times to work around issues
 echo "Executing AWScliSetup.sh"


### PR DESCRIPTION
The `extras` capability takes a list of package names or group
names to be installed by yum in the chroot.