### PR TITLE
Uses the .txt extension for manifest files

### DIFF
--- a/spel/minimal-linux.json
+++ b/spel/minimal-linux.json
@@ -455,8 +455,8 @@
         },
         {
             "type": "file",
-            "source": "/tmp/manifest.log",
-            "destination": ".spel/{{ user `spel_version` }}/{{ user `spel_identifier` }}-{{ build_name }}.manifest",
+            "source": "/tmp/manifest.txt",
+            "destination": ".spel/{{ user `spel_version` }}/{{ user `spel_identifier` }}-{{ build_name }}.manifest.txt",
             "direction": "download"
         },
         {
@@ -478,7 +478,7 @@
             {
                 "type": "artifice",
                 "files": [
-                    ".spel/{{ user `spel_version` }}/{{ user `spel_identifier` }}-{{ build_name }}.manifest"
+                    ".spel/{{ user `spel_version` }}/{{ user `spel_identifier` }}-{{ build_name }}.manifest.txt"
                 ]
             }
         ],

--- a/spel/scripts/amigen6-build.sh
+++ b/spel/scripts/amigen6-build.sh
@@ -196,10 +196,10 @@ echo "Executing PreRelabel.sh"
 bash "${ELBUILD}"/PreRelabel.sh
 
 echo "Saving the aws cli version to the manifest"
-(chroot "${CHROOT}" /usr/bin/aws --version) > /tmp/manifest.log 2>&1
+(chroot "${CHROOT}" /usr/bin/aws --version) > /tmp/manifest.txt 2>&1
 
 echo "Saving the RPM manifest"
-rpm --root "${CHROOT}" -qa | sort -u >> /tmp/manifest.log
+rpm --root "${CHROOT}" -qa | sort -u >> /tmp/manifest.txt
 
 echo "Executing UmountChroot.sh"
 bash "${ELBUILD}"/UmountChroot.sh

--- a/spel/scripts/amigen7-build.sh
+++ b/spel/scripts/amigen7-build.sh
@@ -231,11 +231,11 @@ fi
 if [[ "${CLOUDPROVIDER}" == "aws" ]]
 then
     echo "Saving the aws cli version to the manifest"
-    (chroot "${CHROOT}" /usr/bin/aws --version) > /tmp/manifest.log 2>&1
+    (chroot "${CHROOT}" /usr/bin/aws --version) > /tmp/manifest.txt 2>&1
 elif [[ "${CLOUDPROVIDER}" == "azure" ]]
 then
     echo "Saving the waagent version to the manifest"
-    (chroot "${CHROOT}" /usr/sbin/waagent --version) > /tmp/manifest.log 2>&1
+    (chroot "${CHROOT}" /usr/sbin/waagent --version) > /tmp/manifest.txt 2>&1
 fi
 
 echo "Saving the RPM manifest"


### PR DESCRIPTION
When retrieving the files from s3 via the console, it automatically
applies the .txt extension, so this just acknowledges and aligns
the extension to minimize work when merging the manifests for a
release.
