### PR TITLE
Fixes #154 Partition sizes smaller on AMIs

### DIFF
--- a/spel/kickstarts/ks.centos6.minimal.cfg
+++ b/spel/kickstarts/ks.centos6.minimal.cfg
@@ -24,12 +24,12 @@ part /boot --fstype=ext4 --asprimary --size=200 --ondrive=sda
 part pv.008002 --grow --size=200 --ondrive=sda
 
 volgroup VolGroup00 --pesize=4096 pv.008002
-logvol /              --name=rootVol  --vgname=VolGroup00 --size=1600 --fstype=ext4
-logvol /home          --name=homeVol  --vgname=VolGroup00 --size=400  --fstype=ext4
-logvol /var           --name=varVol   --vgname=VolGroup00 --size=800  --fstype=ext4
-logvol /var/log       --name=logVol   --vgname=VolGroup00 --size=800  --fstype=ext4
-logvol /var/log/audit --name=auditVol --vgname=VolGroup00 --size=3588 --fstype=ext4
-logvol swap           --name=swapVol  --vgname=VolGroup00 --size=800
+logvol /              --name=rootVol  --vgname=VolGroup00 --size=4096 --fstype=ext4
+logvol /home          --name=homeVol  --vgname=VolGroup00 --size=1024  --fstype=ext4
+logvol /var           --name=varVol   --vgname=VolGroup00 --size=2048  --fstype=ext4
+logvol /var/log       --name=logVol   --vgname=VolGroup00 --size=2048  --fstype=ext4
+logvol /var/log/audit --name=auditVol --vgname=VolGroup00 --size=8192 --fstype=ext4
+logvol swap           --name=swapVol  --vgname=VolGroup00 --size=2048
 
 %include /tmp/repo-include
 


### PR DESCRIPTION
Fixes #154 .

Changes offered/proposed in this pull request:
- Partition sizes in Vagrant boxes have been increased 
-This is so the Vagrant box partition sizes more closely resemble those used in the AMIs 
- Fixes out of space erros when Builds that are successful in an AMI run out of space on the Vagrant box

* New PR Alert to: @plus3it/spel
