### PR TITLE
adds tools to deploy spel cicd projects with terraform

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,114 @@
+# SSM-Terraform
+
+This project is designed to automate the deployment of all spel codebuild projects across both Commercial and GovCloud AWS environments.
+
+## Overview
+
+At it's core this project is simply a wrapper for terraform.
+
+It leverages `python_terraform`, `boto3`, and `pyinvoke` in an attempt to enhance ease of use and reduce deployment friction.
+
+Terraform variables can be defined per project ( under the `/environments/` directory of this project ) with a `terraform.tfvars` file, or they can be called at `terraform apply` from the SSM parameter store.
+
+Parameter store variable values can be manipulated by using a `yaml` based template who's structure is outlined below.
+
+Currently only remote state is supported.
+
+## Prerequisites
+
+- Python 3.6+
+- A `*nix` machine
+- configuring a virtual env:
+
+```bash
+python3 -m venv tf
+source tf/bin/activate
+pip3 install -r requirements.txt
+```
+
+### Usage
+
+Note: the `invoke create-env` option configures the target codebuild project(s) with an S3 backed remote state.
+
+To deploy both AWS Commercial and AWS GovCloud TF projects with variable values from SSM:
+
+```bash
+invoke create-env --build-env=all
+```
+
+To deploy a single codebuild project with variable values from SSM:
+
+```bash
+invoke create-env --build-env=<environment_name>
+```
+
+Note: If at any point you experience issues all commands have an included `--verbose` flag.
+
+### destroy
+
+To destroy a targeted CodeBuild environment and it's backend:
+
+```bash
+invoke destroy-env --build-env=commercial_ci --include-backend
+```
+
+To destroy all CodeBuild environments and their backends:
+
+```bash
+invoke destroy-env --build-env=all --include-backend
+```
+
+To destroy the CodeBuild environment and preserve the backend just remove the `--include-backend` flag
+
+Note: Remote state buckets are deployed with versioning on by default and will need to be deleted manually along with the project's like-named DynamoDB table.
+
+### Variables configuration
+
+Variable values are pulled at `terraform apply` from the AWS SSM parameter store. However, these values are configurable/updatable via the cli and the use of a template yaml file.
+
+#### Starting fresh
+
+Create a `varialbles.yaml` file in the root of this directory in the following format:
+
+```yaml
+commercial_ci:
+  -
+      var_name: "VARIABLE_NAME"
+      value: "VARIABLE_VALUE"
+      var_type: String|SecureString
+  -
+      var_name: "VARIABLE_NAME"
+      value: "VARIABLE_VALUE"
+      var_type: String|SecureString
+
+commercial_rc:
+  -
+      var_name: "VARIABLE_NAME"
+      value: "VARIABLE_VALUE"
+      var_type: String|SecureString
+  -
+      var_name: "VARIABLE_NAME"
+      value: "VARIABLE_VALUE"
+      var_type: String|SecureString
+
+...etc...
+
+```
+
+Use the following command to confirm your `variables.yaml` is in the proper format:
+
+```bash
+invoke variables --validate=local
+```
+
+Use the following command to compare your local values to their accompanying SSM values:
+
+```bash
+invoke variables --validate=remote
+```
+
+When you are satisfied with the new values, run the following command to update the remote values with your local values:
+
+```bash
+invoke variables --update
+```

--- a/ci/environments/commercial_ci/backend_init/main.tf
+++ b/ci/environments/commercial_ci/backend_init/main.tf
@@ -1,0 +1,19 @@
+provider "aws" {}
+
+variable "project_name" {}
+variable "stage" {}
+
+module "terraform_state_backend" {
+  source       = "../../../modules/remote_state"
+  namespace    = "spel"
+  stage        = "${var.stage}"
+  project_name = "${replace(var.project_name, "_", "-")}"
+}
+
+output "s3_bucket_id" {
+  value = "${module.terraform_state_backend.s3_bucket_id}"
+}
+
+output "dynamodb_table_name" {
+  value = "${module.terraform_state_backend.dynamodb_table_name}"
+}

--- a/ci/environments/commercial_ci/main.tf
+++ b/ci/environments/commercial_ci/main.tf
@@ -1,0 +1,50 @@
+provider "aws" {}
+
+terraform {
+  backend "s3" {}
+}
+
+locals {
+  environment_variables = [
+    {
+      "name"  = "AWS_REGION"
+      "value" = "${var.commercial_aws_region}"
+    },
+    {
+      "name"  = "SPEL_EXTRARPMS"
+      "value" = "${var.spel_extrapms}"
+    },
+    {
+      "name"  = "SPEL_IDENTIFIER"
+      "value" = "${var.spel_identifier}"
+    },
+    {
+      "name"  = "SPEL_BUILDERS"
+      "value" = "${var.spel_builders}"
+    },
+    {
+      "name"  = "SPEL_CI"
+      "value" = "true"
+    },
+    {
+      "name"  = "SPEL_PIN_AWSCLI_BUNDLE"
+      "value" = "true"
+    },
+  ]
+}
+
+module "amis" {
+  source    = "../../modules/amis"
+  partition = "aws"
+}
+
+module "codebuild" {
+  source = "../../modules"
+
+  project_name          = "spel"
+  build_target_env      = "commercial-ci"
+  ssm_key_name          = "${var.ssm_key_name}"
+  project_description   = "Executes Continuous Integration tests for spel in the Commercial regions"
+  environment_variables = "${local.environment_variables}"
+  target_ami_list       = "${module.amis.ids}"
+}

--- a/ci/environments/commercial_ci/variables.tf
+++ b/ci/environments/commercial_ci/variables.tf
@@ -1,0 +1,8 @@
+variable "ssm_key_name" {}
+variable "spel_extrapms" {}
+variable "spel_builders" {}
+variable "packer_zip" {}
+variable "ami_groups" {}
+variable "ami_regions" {}
+variable "spel_identifier" {}
+variable "commercial_aws_region" {}

--- a/ci/environments/commercial_official/backend_init/main.tf
+++ b/ci/environments/commercial_official/backend_init/main.tf
@@ -1,0 +1,19 @@
+provider "aws" {}
+
+variable "project_name" {}
+variable "stage" {}
+
+module "terraform_state_backend" {
+  source       = "../../../modules/remote_state"
+  namespace    = "spel"
+  stage        = "${var.stage}"
+  project_name = "${replace(var.project_name, "_", "-")}"
+}
+
+output "s3_bucket_id" {
+  value = "${module.terraform_state_backend.s3_bucket_id}"
+}
+
+output "dynamodb_table_name" {
+  value = "${module.terraform_state_backend.dynamodb_table_name}"
+}

--- a/ci/environments/commercial_official/main.tf
+++ b/ci/environments/commercial_official/main.tf
@@ -1,0 +1,54 @@
+provider "aws" {}
+
+terraform {
+  backend "s3" {}
+}
+
+locals {
+  environment_variables = [
+    {
+      "name"  = "AWS_REGION"
+      "value" = "${var.commercial_aws_region}"
+    },
+    {
+      "name"  = "SPEL_EXTRARPMS"
+      "value" = "${var.spel_extrapms}"
+    },
+    {
+      "name"  = "SPEL_IDENTIFIER"
+      "value" = "${var.spel_identifier}"
+    },
+    {
+      "name"  = "SPEL_BUILDERS"
+      "value" = "${var.spel_builders}"
+    },
+    {
+      "name"  = "PACKER_ZIP"
+      "value" = "${var.packer_zip}"
+    },
+    {
+      "name"  = "AMI_GROUPS"
+      "value" = "${var.ami_groups}"
+    },
+    {
+      "name"  = "AMI_REGIONS"
+      "value" = "${var.ami_regions}"
+    },
+  ]
+}
+
+module "amis" {
+  source    = "../../modules/amis"
+  partition = "aws"
+}
+
+module "codebuild" {
+  source = "../../modules"
+
+  project_name          = "spel"
+  build_target_env      = "commercial-official"
+  ssm_key_name          = "${var.ssm_key_name}"
+  project_description   = "Executes Continuous Integration tests for spel in the Commercial regions"
+  environment_variables = "${local.environment_variables}"
+  target_ami_list       = "${module.amis.ids}"
+}

--- a/ci/environments/commercial_official/variables.tf
+++ b/ci/environments/commercial_official/variables.tf
@@ -1,0 +1,8 @@
+variable "ssm_key_name" {}
+variable "spel_extrapms" {}
+variable "spel_builders" {}
+variable "packer_zip" {}
+variable "ami_groups" {}
+variable "ami_regions" {}
+variable "spel_identifier" {}
+variable "commercial_aws_region" {}

--- a/ci/environments/commercial_rc/backend_init/main.tf
+++ b/ci/environments/commercial_rc/backend_init/main.tf
@@ -1,0 +1,19 @@
+provider "aws" {}
+
+variable "project_name" {}
+variable "stage" {}
+
+module "terraform_state_backend" {
+  source       = "../../../modules/remote_state"
+  namespace    = "spel"
+  stage        = "${var.stage}"
+  project_name = "${replace(var.project_name, "_", "-")}"
+}
+
+output "s3_bucket_id" {
+  value = "${module.terraform_state_backend.s3_bucket_id}"
+}
+
+output "dynamodb_table_name" {
+  value = "${module.terraform_state_backend.dynamodb_table_name}"
+}

--- a/ci/environments/commercial_rc/main.tf
+++ b/ci/environments/commercial_rc/main.tf
@@ -1,0 +1,46 @@
+provider "aws" {}
+
+terraform {
+  backend "s3" {}
+}
+
+locals {
+  environment_variables = [
+    {
+      "name"  = "AWS_REGION"
+      "value" = "${var.commercial_aws_region}"
+    },
+    {
+      "name"  = "SPEL_EXTRARPMS"
+      "value" = "${var.spel_extrapms}"
+    },
+    {
+      "name"  = "SPEL_IDENTIFIER"
+      "value" = "${var.spel_identifier}"
+    },
+    {
+      "name"  = "SPEL_BUILDERS"
+      "value" = "${var.spel_builders}"
+    },
+    {
+      "name"  = "PACKER_ZIP"
+      "value" = "${var.packer_zip}"
+    },
+  ]
+}
+
+module "amis" {
+  source    = "../../modules/amis"
+  partition = "aws"
+}
+
+module "codebuild" {
+  source = "../../modules/"
+
+  project_name          = "spel"
+  build_target_env      = "commercial-rc"
+  ssm_key_name          = "${var.ssm_key_name}"
+  project_description   = "Builds \"spel\" Release Candidate (RC) AMIs for AWS Commercial Regions"
+  environment_variables = "${local.environment_variables}"
+  target_ami_list       = "${module.amis.ids}"
+}

--- a/ci/environments/commercial_rc/variables.tf
+++ b/ci/environments/commercial_rc/variables.tf
@@ -1,0 +1,6 @@
+variable "ssm_key_name" {}
+variable "spel_extrapms" {}
+variable "spel_builders" {}
+variable "packer_zip" {}
+variable "spel_identifier" {}
+variable "commercial_aws_region" {}

--- a/ci/environments/govcloud_ci/backend_init/main.tf
+++ b/ci/environments/govcloud_ci/backend_init/main.tf
@@ -1,0 +1,19 @@
+provider "aws" {}
+
+variable "project_name" {}
+variable "stage" {}
+
+module "terraform_state_backend" {
+  source       = "../../../modules/remote_state"
+  namespace    = "spel"
+  stage        = "${var.stage}"
+  project_name = "${replace(var.project_name, "_", "-")}"
+}
+
+output "s3_bucket_id" {
+  value = "${module.terraform_state_backend.s3_bucket_id}"
+}
+
+output "dynamodb_table_name" {
+  value = "${module.terraform_state_backend.dynamodb_table_name}"
+}

--- a/ci/environments/govcloud_ci/main.tf
+++ b/ci/environments/govcloud_ci/main.tf
@@ -1,0 +1,75 @@
+provider "aws" {
+  alias = "commercial"
+}
+
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  alias      = "govcloud"
+  region     = "${var.govcloud_region}"
+  access_key = "${var.govcloud_access_key}"
+  secret_key = "${var.govcloud_secret_key}"
+}
+
+locals {
+  environment_variables = [
+    {
+      "name"  = "AWS_REGION"
+      "value" = "${var.commercial_aws_region}"
+    },
+    {
+      "name"  = "SPEL_EXTRARPMS"
+      "value" = "${var.spel_extrapms}"
+    },
+    {
+      "name"  = "SPEL_IDENTIFIER"
+      "value" = "${var.spel_identifier}"
+    },
+    {
+      "name"  = "SPEL_BUILDERS"
+      "value" = "${var.spel_builders}"
+    },
+    {
+      "name"  = "SPEL_SSM_ACCESS_KEY"
+      "value" = "${var.spel_ssm_access_key}"
+    },
+    {
+      "name"  = "SPEL_SSM_SECRET_KEY"
+      "value" = "${var.spel_ssm_secret_key}"
+    },
+    {
+      "name"  = "SPEL_CI"
+      "value" = "${var.spel_ci}"
+    },
+    {
+      "name"  = "SPEL_PIN_AWSCLI_BUNDLE"
+      "value" = "${var.spel_pin_awscli_bundle}"
+    },
+  ]
+}
+
+module "amis" {
+  source    = "../../modules/amis"
+  partition = "aws-us-gov"
+
+  providers = {
+    aws = "aws.govcloud"
+  }
+}
+
+module "codebuild" {
+  source = "../../modules/"
+
+  providers = {
+    aws = "aws.commercial"
+  }
+
+  project_name          = "spel"
+  build_target_env      = "govcloud-ci"
+  ssm_key_name          = "${var.ssm_key_name}"
+  project_description   = "Executes Continuous Integration tests for spel in the GovCloud region"
+  target_ami_list       = "${module.amis.ids}"
+  environment_variables = "${local.environment_variables}"
+}

--- a/ci/environments/govcloud_ci/variables.tf
+++ b/ci/environments/govcloud_ci/variables.tf
@@ -1,0 +1,13 @@
+variable "commercial_aws_region" {}
+variable "ssm_key_name" {}
+variable "govcloud_region" {}
+variable "govcloud_access_key" {}
+variable "govcloud_secret_key" {}
+variable "spel_identifier" {}
+variable "spel_builders" {}
+variable "spel_extrapms" {}
+variable "spel_ssm_access_key" {}
+variable "spel_ssm_secret_key" {}
+variable "aws_region" {}
+variable "spel_ci" {}
+variable "spel_pin_awscli_bundle" {}

--- a/ci/environments/govcloud_official/backend_init/main.tf
+++ b/ci/environments/govcloud_official/backend_init/main.tf
@@ -1,0 +1,19 @@
+provider "aws" {}
+
+variable "project_name" {}
+variable "stage" {}
+
+module "terraform_state_backend" {
+  source       = "../../../modules/remote_state"
+  namespace    = "spel"
+  stage        = "${var.stage}"
+  project_name = "${replace(var.project_name, "_", "-")}"
+}
+
+output "s3_bucket_id" {
+  value = "${module.terraform_state_backend.s3_bucket_id}"
+}
+
+output "dynamodb_table_name" {
+  value = "${module.terraform_state_backend.dynamodb_table_name}"
+}

--- a/ci/environments/govcloud_official/main.tf
+++ b/ci/environments/govcloud_official/main.tf
@@ -1,0 +1,75 @@
+provider "aws" {
+  alias = "commercial"
+}
+
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  alias      = "govcloud"
+  region     = "${var.govcloud_region}"
+  access_key = "${var.govcloud_access_key}"
+  secret_key = "${var.govcloud_secret_key}"
+}
+
+locals {
+  environment_variables = [
+    {
+      "name"  = "AWS_REGION"
+      "value" = "${var.commercial_aws_region}"
+    },
+    {
+      "name"  = "SPEL_EXTRARPMS"
+      "value" = "${var.spel_extrapms}"
+    },
+    {
+      "name"  = "SPEL_IDENTIFIER"
+      "value" = "${var.spel_identifier}"
+    },
+    {
+      "name"  = "SPEL_BUILDERS"
+      "value" = "${var.spel_builders}"
+    },
+    {
+      "name"  = "SPEL_SSM_ACCESS_KEY"
+      "value" = "${var.spel_ssm_access_key}"
+    },
+    {
+      "name"  = "SPEL_SSM_SECRET_KEY"
+      "value" = "${var.spel_ssm_secret_key}"
+    },
+    {
+      "name"  = "AMI_GROUPS"
+      "value" = "${var.ami_groups}"
+    },
+    {
+      "name"  = "AMI_REGIONS"
+      "value" = "${var.ami_regions}"
+    },
+  ]
+}
+
+module "amis" {
+  source    = "../../modules/amis"
+  partition = "aws-us-gov"
+
+  providers = {
+    aws = "aws.govcloud"
+  }
+}
+
+module "codebuild" {
+  source = "../../modules/"
+
+  providers = {
+    aws = "aws.commercial"
+  }
+
+  project_name          = "spel"
+  build_target_env      = "govcloud-official"
+  ssm_key_name          = "${var.ssm_key_name}"
+  project_description   = "Builds \"spel\" Official (Public) AMIs for AWS GovCloud Region(s)"
+  target_ami_list       = "${module.amis.ids}"
+  environment_variables = "${local.environment_variables}"
+}

--- a/ci/environments/govcloud_official/variables.tf
+++ b/ci/environments/govcloud_official/variables.tf
@@ -1,0 +1,13 @@
+variable "ssm_key_name" {}
+variable "commercial_aws_region" {}
+variable "govcloud_region" {}
+variable "govcloud_access_key" {}
+variable "govcloud_secret_key" {}
+variable "spel_identifier" {}
+variable "spel_builders" {}
+variable "spel_extrapms" {}
+variable "spel_ssm_access_key" {}
+variable "spel_ssm_secret_key" {}
+variable "ami_groups" {}
+variable "ami_regions" {}
+variable "aws_region" {}

--- a/ci/environments/govcloud_rc/backend_init/main.tf
+++ b/ci/environments/govcloud_rc/backend_init/main.tf
@@ -1,0 +1,19 @@
+provider "aws" {}
+
+variable "project_name" {}
+variable "stage" {}
+
+module "terraform_state_backend" {
+  source       = "../../../modules/remote_state"
+  namespace    = "spel"
+  stage        = "${var.stage}"
+  project_name = "${replace(var.project_name, "_", "-")}"
+}
+
+output "s3_bucket_id" {
+  value = "${module.terraform_state_backend.s3_bucket_id}"
+}
+
+output "dynamodb_table_name" {
+  value = "${module.terraform_state_backend.dynamodb_table_name}"
+}

--- a/ci/environments/govcloud_rc/main.tf
+++ b/ci/environments/govcloud_rc/main.tf
@@ -1,0 +1,67 @@
+provider "aws" {
+  alias = "commercial"
+}
+
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  alias      = "govcloud"
+  region     = "${var.govcloud_region}"
+  access_key = "${var.govcloud_access_key}"
+  secret_key = "${var.govcloud_secret_key}"
+}
+
+locals {
+  environment_variables = [
+    {
+      "name"  = "AWS_REGION"
+      "value" = "${var.commercial_aws_region}"
+    },
+    {
+      "name"  = "SPEL_EXTRARPMS"
+      "value" = "${var.spel_extrapms}"
+    },
+    {
+      "name"  = "SPEL_IDENTIFIER"
+      "value" = "${var.spel_identifier}"
+    },
+    {
+      "name"  = "SPEL_BUILDERS"
+      "value" = "${var.spel_builders}"
+    },
+    {
+      "name"  = "SPEL_SSM_ACCESS_KEY"
+      "value" = "${var.spel_ssm_access_key}"
+    },
+    {
+      "name"  = "SPEL_SSM_SECRET_KEY"
+      "value" = "${var.spel_ssm_secret_key}"
+    },
+  ]
+}
+
+module "amis" {
+  source    = "../../modules/amis"
+  partition = "aws-us-gov"
+
+  providers = {
+    aws = "aws.govcloud"
+  }
+}
+
+module "codebuild" {
+  source = "../../modules/"
+
+  providers = {
+    aws = "aws.commercial"
+  }
+
+  project_name          = "spel"
+  build_target_env      = "govcloud-rc"
+  ssm_key_name          = "${var.ssm_key_name}"
+  project_description   = "Builds \"spel\" Release Candidate (RC) AMIs for AWS GovCloud Region(s)"
+  environment_variables = ["${local.environment_variables}"]
+  target_ami_list       = "${module.amis.ids}"
+}

--- a/ci/environments/govcloud_rc/variables.tf
+++ b/ci/environments/govcloud_rc/variables.tf
@@ -1,0 +1,10 @@
+variable "ssm_key_name" {}
+variable "govcloud_region" {}
+variable "govcloud_access_key" {}
+variable "govcloud_secret_key" {}
+variable "spel_identifier" {}
+variable "spel_builders" {}
+variable "spel_extrapms" {}
+variable "spel_ssm_access_key" {}
+variable "spel_ssm_secret_key" {}
+variable "commercial_aws_region" {}

--- a/ci/modules/amis/main.tf
+++ b/ci/modules/amis/main.tf
@@ -1,0 +1,113 @@
+variable "partition" {} # "aws" or "aws-us-gov"
+
+locals {
+  centos_ami_owners = {
+    aws        = "701759196663"
+    aws-us-gov = "039368651566"
+  }
+
+  rhel_ami_owners = {
+    aws        = "309956199498"
+    aws-us-gov = "219670896067"
+  }
+}
+
+//rhel6 hvm - commercial
+data "aws_ami" "rhel6_hvm_com" {
+  most_recent = true
+
+  filter {
+    name   = "owner-id"
+    values = ["${local.rhel_ami_owners[var.partition]}"]
+  }
+
+  filter {
+    name   = "name"
+    values = ["RHEL-6.*_HVM*-x86_64-*-GP2"]
+  }
+}
+
+//rhel7_hvm commercial
+data "aws_ami" "rhel7_hvm_com" {
+  most_recent = true
+
+  filter {
+    name   = "owner-id"
+    values = ["${local.rhel_ami_owners[var.partition]}"]
+  }
+
+  filter {
+    name   = "name"
+    values = ["RHEL-7.*_HVM*-x86_64-*-GP2"]
+  }
+}
+
+//centos6_hvm commercial
+data "aws_ami" "centos6_hvm_com" {
+  most_recent = true
+
+  filter {
+    name   = "owner-id"
+    values = ["${local.centos_ami_owners[var.partition]}"]
+  }
+
+  filter {
+    name   = "name"
+    values = ["*Recovery*CentOS6-HVM"]
+  }
+}
+
+//centos6_pvm commercial
+data "aws_ami" "centos6_pvm_com" {
+  most_recent = true
+
+  filter {
+    name   = "owner-id"
+    values = ["${local.centos_ami_owners[var.partition]}"]
+  }
+
+  filter {
+    name   = "name"
+    values = ["*Recovery*CentOS6-PVM"]
+  }
+}
+
+//centos7_hvm commercial
+data "aws_ami" "centos7_hvm_com" {
+  most_recent = true
+
+  filter {
+    name   = "owner-id"
+    values = ["${local.centos_ami_owners[var.partition]}"]
+  }
+
+  filter {
+    name   = "name"
+    values = ["*Recovery*CentOS7-HVM*"]
+  }
+}
+
+output "ids" {
+  value = [
+    {
+      "name"  = "SOURCE_AMI_CENTOS6_HVM"
+      "value" = "${data.aws_ami.centos6_hvm_com.id}"
+    },
+    {
+      "name"  = "SOURCE_AMI_CENTOS6_PVM"
+      "value" = "${data.aws_ami.centos6_pvm_com.id}"
+    },
+    {
+      "name"  = "SOURCE_AMI_CENTOS7_HVM"
+      "value" = "${data.aws_ami.centos7_hvm_com.id}"
+    },
+    {
+      "name"  = "SOURCE_AMI_RHEL6_HVM"
+      "value" = "${data.aws_ami.rhel6_hvm_com.id}"
+    },
+    {
+      "name"  = "SOURCE_AMI_RHEL7_HVM"
+      "value" = "${data.aws_ami.rhel7_hvm_com.id}"
+    },
+  ]
+}

--- a/ci/modules/iam/main.tf
+++ b/ci/modules/iam/main.tf
@@ -1,0 +1,145 @@
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role" "spel-codebuild-role" {
+  name = "${var.project_name}-codebuild"
+  path = "/service-role/"
+
+  assume_role_policy = <<-POLICY
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "codebuild.amazonaws.com"
+          },
+          "Action": "sts:AssumeRole"
+        }
+      ]
+    }
+    POLICY
+}
+
+resource "aws_iam_role_policy" "packer-codebuild-permissions" {
+  name = "packer-codebuild-permissions"
+  role = "${aws_iam_role.spel-codebuild-role.name}"
+
+  policy = <<-POLICY
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Resource": [
+                    "arn:aws:logs:us-east-1:${data.aws_caller_identity.current.account_id}:log-group:/aws/codebuild/spel-ci",
+                    "arn:aws:logs:us-east-1:${data.aws_caller_identity.current.account_id}:log-group:/aws/codebuild/spel-ci:*"
+                ],
+                "Action": [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents"
+                ]
+            },
+            {
+                "Effect": "Allow",
+                "Resource": [
+                    "arn:aws:s3:::spel-ci/*"
+                ],
+                "Action": [
+                    "s3:PutObject"
+                ]
+            }
+        ]
+    }
+    POLICY
+}
+
+resource "aws_iam_role_policy" "packer-ec2-permissions" {
+  name = "packer-ec2-permissions"
+  role = "${aws_iam_role.spel-codebuild-role.name}"
+
+  policy = <<-POLICY
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "ec2:AttachVolume",
+                    "ec2:AuthorizeSecurityGroupIngress",
+                    "ec2:CopyImage",
+                    "ec2:CreateImage",
+                    "ec2:CreateKeypair",
+                    "ec2:CreateSecurityGroup",
+                    "ec2:CreateSnapshot",
+                    "ec2:CreateTags",
+                    "ec2:CreateVolume",
+                    "ec2:DeleteKeypair",
+                    "ec2:DeleteSecurityGroup",
+                    "ec2:DeleteSnapshot",
+                    "ec2:DeleteVolume",
+                    "ec2:DeregisterImage",
+                    "ec2:DescribeImageAttribute",
+                    "ec2:DescribeImages",
+                    "ec2:DescribeInstances",
+                    "ec2:DescribeInstanceStatus",
+                    "ec2:DescribeRegions",
+                    "ec2:DescribeSecurityGroups",
+                    "ec2:DescribeSnapshots",
+                    "ec2:DescribeSubnets",
+                    "ec2:DescribeTags",
+                    "ec2:DescribeVolumes",
+                    "ec2:DetachVolume",
+                    "ec2:GetPasswordData",
+                    "ec2:ModifyImageAttribute",
+                    "ec2:ModifyInstanceAttribute",
+                    "ec2:ModifySnapshotAttribute",
+                    "ec2:RegisterImage",
+                    "ec2:RunInstances",
+                    "ec2:StopInstances",
+                    "ec2:TerminateInstances"
+                ],
+                "Resource": "*"
+            }
+        ]
+    }
+    POLICY
+}
+
+data "aws_kms_key" "ssm_key" {
+  key_id = "alias/${var.ssm_key_name}"
+}
+
+resource "aws_iam_role_policy" "packer-ssm-permissions" {
+  name = "packer-ssm-permissions"
+  role = "${aws_iam_role.spel-codebuild-role.name}"
+
+  policy = <<-POLICY
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AllowSsmGetParameters",
+                "Effect": "Allow",
+                "Action": [
+                    "ssm:GetParameters"
+                ],
+                "Resource": "arn:aws:ssm:*:*:parameter/spel/*"
+            },
+            {
+                "Sid": "AllowKmsDecrypt",
+                "Effect": "Allow",
+                "Action": [
+                    "kms:Decrypt"
+                ],
+                "Resource": "arn:aws:kms:*:*:key/${data.aws_kms_key.ssm_key.id}"
+            }
+        ]
+    }
+    POLICY
+}
+
+output "role_arn" {
+  description = "ARN of the created role"
+  value       = "${aws_iam_role.spel-codebuild-role.arn}"
+}

--- a/ci/modules/iam/variables.tf
+++ b/ci/modules/iam/variables.tf
@@ -1,0 +1,9 @@
+variable "ssm_key_name" {
+  type        = "string"
+  description = "Alias of the target account's ssm key"
+}
+
+variable "project_name" {
+  type        = "string"
+  description = "Name of the project"
+}

--- a/ci/modules/main.tf
+++ b/ci/modules/main.tf
@@ -1,0 +1,57 @@
+provider "aws" {}
+
+// bucket: spel-cicd-testing
+locals {
+  full_project_name     = "${var.project_name}-${var.build_target_env}-test"
+  artifacts_bucket_name = "${local.full_project_name}-codebuild-artifacts"
+}
+
+//configure the S3 buckets for codebuild logging and terraform artifacts
+
+resource "aws_s3_bucket" "codebuild_artifacts" {
+  bucket = "${local.artifacts_bucket_name}"
+  acl    = "private"
+}
+
+//Import the iam module
+//Creates project specific roles
+module "iam" {
+  source       = "iam"
+  ssm_key_name = "${var.ssm_key_name}"
+  project_name = "${local.full_project_name}"
+}
+
+//Create the codebuild project
+resource "aws_codebuild_project" "example" {
+  name          = "${local.full_project_name}"
+  description   = "${var.project_description}"
+  build_timeout = "75"
+  service_role  = "${module.iam.role_arn}"
+
+  artifacts {
+    type     = "S3"
+    location = "${local.artifacts_bucket_name}"
+    name     = "${local.full_project_name}"
+
+    //  path     = "${var.build_target_env}/artifacts"
+    path = "/"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "aws/codebuild/ubuntu-base:14.04"
+    type         = "LINUX_CONTAINER"
+
+    environment_variable = ["${var.environment_variables}", "${var.target_ami_list}"]
+  }
+
+  source {
+    type            = "GITHUB"
+    location        = "https://github.com/plus3it/spel"
+    git_clone_depth = 0
+  }
+
+  tags {
+    "Environment" = "${var.build_target_env}"
+  }
+}

--- a/ci/modules/remote_state/main.tf
+++ b/ci/modules/remote_state/main.tf
@@ -1,0 +1,12 @@
+provider "aws" {}
+
+data "aws_region" "current" {}
+
+module "terraform_state_backend" {
+  source     = "git::https://github.com/cloudposse/terraform-aws-tfstate-backend.git?ref=master"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.project_name}"
+  attributes = ["state"]
+  region     = "${data.aws_region.current.name}"
+}

--- a/ci/modules/remote_state/outputs.tf
+++ b/ci/modules/remote_state/outputs.tf
@@ -1,0 +1,9 @@
+output "s3_bucket_id" {
+  value       = "${module.terraform_state_backend.s3_bucket_id}"
+  description = "S3 bucket ID"
+}
+
+output "dynamodb_table_name" {
+  value       = "${module.terraform_state_backend.dynamodb_table_name}"
+  description = "DynamoDB table name"
+}

--- a/ci/modules/remote_state/variables.tf
+++ b/ci/modules/remote_state/variables.tf
@@ -1,0 +1,14 @@
+variable "stage" {
+  type        = "string"
+  default     = "test"
+  description = "test|dev|prod"
+}
+
+variable "project_name" {
+  type        = "string"
+  description = "name of the project"
+}
+
+variable "namespace" {
+  type = "string"
+}

--- a/ci/modules/variables.tf
+++ b/ci/modules/variables.tf
@@ -1,0 +1,43 @@
+variable "project_name" {
+  type        = "string"
+  description = "The name of the project"
+}
+
+variable "build_target_env" {
+  type        = "string"
+  description = "What the codebuild project is tarteting ie: commercial_ci, govcloud_rc, etc."
+}
+
+variable "ssm_key_name" {
+  type        = "string"
+  description = "Alias of the target account's ssm key"
+}
+
+variable "project_description" {
+  type        = "string"
+  description = "codebuild project description"
+}
+
+variable "target_ami_list" {
+  type        = "list"
+  description = "List of maps containing the environment varabiles for the target amis"
+}
+
+variable "environment_variables" {
+  type = "list"
+
+  default     = []
+  description = "list of maps containing additional environment variables for codebuild. Expects a \"name\" and \"value\" keypair"
+
+  # Example:
+  # environment_variables = [
+  #   {
+  #     "name"  = "TEST_VAR_1"
+  #     "value" = "TRUE"
+  #   },
+  #   {
+  #     "name"  = "TEST_VAR_2"
+  #     "value" = "TRUE"
+  #   },
+  # ]
+}

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,0 +1,4 @@
+boto3==1.7.65
+invoke==1.1.0
+python-terraform==0.10.0
+PyYAML==3.13

--- a/ci/s3.py
+++ b/ci/s3.py
@@ -1,0 +1,65 @@
+"""Deletes all s3 objects."""
+# modified from https://gist.github.com/seventhskye/0cc7b2804252975d36dca047ab7729e9s
+
+import boto3
+
+client = boto3.client('s3')
+
+
+def delete_all_objects(bucket, prefix='', verbose=False):
+    """Delete all s3 objects and their versions."""
+    IsTruncated = True
+    MaxKeys = 1000
+    KeyMarker = None
+    try:
+        while IsTruncated:
+            if not KeyMarker:
+                    version_list = client.list_object_versions(
+                            Bucket=bucket,
+                            MaxKeys=MaxKeys,
+                            Prefix=prefix)
+            else:
+                    version_list = client.list_object_versions(
+                            Bucket=bucket,
+                            MaxKeys=MaxKeys,
+                            Prefix=prefix,
+                            KeyMarker=KeyMarker)
+
+            try:
+                objects = []
+                versions = version_list['Versions']
+                for v in versions:
+                    objects.append(
+                          {
+                            'VersionId': v['VersionId'],
+                            'Key': v['Key']
+                          }
+                      )
+                    response = client.delete_objects(
+                      Bucket=bucket, Delete={'Objects': objects})
+                    if verbose:
+                        print(response)
+            except KeyError:
+                pass
+
+                try:
+                    objects = []
+                    delete_markers = version_list['DeleteMarkers']
+                    for d in delete_markers:
+                        objects.append(
+                              {
+                                'VersionId': d['VersionId'],
+                                'Key': d['Key']
+                              }
+                          )
+                    response = client.delete_objects(
+                      Bucket=bucket, Delete={'Objects': objects})
+                    if verbose:
+                        print(response)
+                except KeyError:
+                    pass
+                    IsTruncated = version_list['IsTruncated']
+                    KeyMarker = version_list['NextKeyMarker']
+    except KeyError:
+        if verbose:
+            print("{} is empty".format(bucket))

--- a/ci/ssm.py
+++ b/ci/ssm.py
@@ -1,0 +1,245 @@
+"""SSM handler."""
+import boto3
+import yaml
+
+import tasks
+
+SPEL_PATH = "/spel/"
+
+
+def load_local_parameters():
+    """Load parameters from source yaml file."""
+    try:
+        stream = open('variables.yaml', 'r')
+        param_obj = yaml.load(stream)
+        return param_obj
+    except FileNotFoundError:
+        print('variables.yaml file was not found. Make sure it exists and is'
+              ' named correctly.')
+        exit()
+
+
+def validate_parameters(param_obj):
+    """Validate the paramater object."""
+    try:
+        for key, var_list in param_obj.items():
+            for var in var_list:
+                try:
+                    if not var['var_name']:
+                        print('A variable block in the {} section was found'
+                              ' with a blank a var_name'
+                              ' declaration'.format(key))
+                except KeyError:
+                    print('A variable block in the {} section was found'
+                          ' without a var_name declaration'.format(key))
+                    exit()
+                try:
+                    if not var['value']:
+                        print('A variable block in the {} section was found'
+                              ' with a value of None'.format(key))
+                except KeyError:
+                    print('A variable block in the {} section was found'
+                          ' without a value declaration'.format(key))
+                    exit()
+                try:
+                    if var['var_type'] != "SecureString"  \
+                            and var['var_type'] != "String":
+                            print('A variable block in the {} section was'
+                                  ' found with an invalid var_type value:'
+                                  ' var_type must be \"String\" '
+                                  ' or \"SecureString\" \n'.format(key))
+                            print("Found value: {} \nExpected value:"
+                                  " \"String\" or \"SecureString\""
+                                  "\n".format(var['var_type']))
+                            exit()
+                except KeyError:
+                    print('A variable block in the {} section was found'
+                          ' without a var_type declaration'.format(key))
+                    exit()
+        print("No potential issues found.")
+    except KeyError:
+        print("variables.yaml is not formatted correctly.")
+        raise
+
+
+def put_parameter(name, value, var_type):
+    """Set parameters in ssm."""
+    # print("updating var: {}".format(name))
+    ssm = boto3.client('ssm')
+    ssm.put_parameter(
+        Name=name,
+        Description='',
+        Value=value,
+        Type=var_type,
+        Overwrite=True
+    )
+
+
+def parse_local_parameters(param_obj, verbose=None):
+    """Parse the source parameter object."""
+    for key in param_obj:
+        for var in param_obj[key]:
+            name = "{0}{1}/{2}".format(SPEL_PATH, key, var['var_name'])
+            value = var['value']
+            var_type = var['var_type']
+            if verbose:
+                print("Adding parameter:"
+                      "\n     Name: {}".format(name) +
+                      "\n     Value: {}".format(value) +
+                      "\n     Type: {}".format(var_type))
+            put_parameter(name, value, var_type)
+
+
+def get_parameters(client, path, **kwargs):
+    """Get SSM parameters."""
+    next_token = kwargs.get('next_token', None)
+    verbose = kwargs.get('verbose', None)
+    if next_token:
+        response = client.get_parameters_by_path(
+            Path=path,
+            Recursive=True,
+            WithDecryption=True,
+            MaxResults=10,
+            NextToken=next_token
+        )
+        if verbose:
+            print("Recieved NextToken with response: {}".format(response))
+    else:
+        response = client.get_parameters_by_path(
+            Path=path,
+            Recursive=True,
+            WithDecryption=True,
+            MaxResults=10
+        )
+        if verbose:
+            print("Recieved response: {}".format(response))
+    return response
+
+
+def get_env_paths():
+    """Get environment variable (ssm) paths."""
+    environment_paths = []
+    for environment in tasks.ENVIRONMENTS:
+        environment_paths.append("{0}{1}".format(SPEL_PATH, environment))
+    return environment_paths
+
+
+def get_ssm_path(env):
+    """Return the ssm path for an environment."""
+    return "{}{}/".format(SPEL_PATH, env)
+
+
+def get_parameters_by_path(path):
+    """Get all parameters."""
+    parameters = []
+    client = boto3.client('ssm')
+    response = get_parameters(client, path)
+    parameters += response['Parameters']
+    try:
+        while response['NextToken']:
+            response = get_parameters(client, path,
+                                      next_token=response['NextToken'])
+            parameters += response['Parameters']
+    except KeyError:
+        return parameters
+
+
+def get_all_remote_parameters():
+    """Get all variable values."""
+    parameters = []
+    paths = get_env_paths()
+    for path in paths:
+        parameters += get_parameters_by_path(path)
+    return parameters
+
+
+def compare_ssm_to_local(verbose=None, target_env=None):
+    """Compare variables.yaml file to SSM."""
+    ssm_values = get_all_remote_parameters()
+    local_values = load_local_parameters()
+    # targeted environment search
+    if target_env:
+        local_values = local_values[target_env]
+        ssm_path = "{}{}/".format(SPEL_PATH, target_env)
+        for local_variable in local_values:
+            for ssm_variable in ssm_values:
+                ssm_var_name = ssm_variable['Name'].replace(ssm_path, '')
+                if (
+                    SPEL_PATH not in ssm_var_name and
+                    local_variable['var_name'] == ssm_var_name
+                ):
+                    if ssm_variable['Value'] != local_variable['value']:
+                        print("Local var {} in {}".format(
+                              local_variable['var_name'], target_env) +
+                              "does not match remote {} ".format(
+                              ssm_variable['Name']) +
+                              "\nremote value: {} ".format(
+                              ssm_variable['Value']) +
+                              "\nlocal value: {} \n".format(
+                              local_variable['value']))
+                    else:
+                        if verbose:
+                            print("Local var {} in {}".format(
+                                  local_variable['var_name'], target_env) +
+                                  " matches remote {}".format(
+                                  ssm_variable['Name']))
+    else:
+        # search across all environments
+        for env in local_values:
+            ssm_path = "{}{}/".format(SPEL_PATH, env)
+            for local_variable in local_values[env]:
+                for ssm_variable in ssm_values:
+                    ssm_var_name = ssm_variable['Name'].replace(ssm_path, '')
+                    if (
+                        SPEL_PATH not in ssm_var_name and
+                        local_variable['var_name'] == ssm_var_name
+                    ):
+                        if ssm_variable['Value'] != local_variable['value']:
+                                print("Local var {} in {}".format(
+                                      local_variable['var_name'], env) +
+                                      " does not match remote {}".format(
+                                        ssm_variable['Name']) +
+                                      "\nremote value: {} ".format(
+                                        ssm_variable['Value']) +
+                                      "\nlocal value: {} ".format(
+                                        local_variable['value']) +
+                                      "\n")
+                        else:
+                            if verbose:
+                                print("Local var {} in {}".format(
+                                      local_variable['var_name'], env) +
+                                      " matches remote {}".format(
+                                      ssm_variable['Name']))
+                    else:
+                        continue
+
+
+def local_parameter_check():
+    """Validate local variables.yaml file."""
+    param_obj = load_local_parameters()
+    validate_parameters(param_obj)
+
+
+def set_remote_variables_from_file(verbose=None):
+    """Set variable values from a local file."""
+    param_obj = load_local_parameters()
+    validate_parameters(param_obj)
+    parse_local_parameters(param_obj, verbose=verbose)
+
+
+def set_remote_variables_from_obj(input_obj, verbose=None):
+    """Set variable values from an input object"""
+    validate_parameters(input_obj)
+    parse_local_parameters(input_obj, verbose=verbose)
+
+
+def get_targeted_variables(env):
+    """Get variables for targeted environment."""
+    variables = {}
+    ssm_path = get_ssm_path(env)
+    parameters = get_parameters_by_path(ssm_path)
+    for tf_var in parameters:
+        if tf_var['Name']:
+            variables[tf_var['Name'].replace(ssm_path, '')] = (
+              tf_var['Value'])
+    return variables

--- a/ci/tasks.py
+++ b/ci/tasks.py
@@ -1,0 +1,359 @@
+"""Deploys SPEL terraform projects."""
+
+import os
+
+import python_terraform
+import s3
+import ssm
+from invoke import task
+
+ENVIRONMENTS = []
+
+ZONES = [
+    "commercial",
+    "govcloud"
+]
+
+PROJECT_STAGES = [
+    "ci",
+    "rc",
+    "official"
+]
+
+for stage in PROJECT_STAGES:
+    for zone in ZONES:
+        ENVIRONMENTS.append("{}_{}".format(zone, stage))
+
+
+def env_check(build_env):
+    """validate provided environment exists within the global
+    ENVIRONMENTS variable."""
+    if build_env not in ENVIRONMENTS:
+        print("\nERROR: the supplied build environment"
+              " \"{}\"".format(build_env) +
+              " does not exist. Exiting..\n")
+        exit()
+
+
+def get_directory(env):
+    """Get the tf project directory."""
+    return (os.getcwd() + "/environments/" + env)
+
+
+def get_tf_handler(build_env, sub_dir=None):
+    """return tf handler."""
+    directory = get_directory(build_env)
+    if sub_dir:
+        directory = "{}/{}".format(directory, sub_dir)
+    return python_terraform.Terraform(directory)
+
+
+def tf_init(tf, backend_config=None, verbose=False):
+    """Initialize target terraform project."""
+    if verbose and backend_config:
+        print('\ntf_init: passing the following backend config:'
+              ' {}\n'.format(backend_config))
+        tf.init(capture_output='True', backend_config=backend_config)
+    elif verbose and not backend_config:
+        print("\nRunning `terraform init`\n")
+        tf.init(capture_output='True')
+    else:
+        tf.init(backend_config=backend_config)
+
+
+# ################################
+#
+# remote state backend specifics
+#
+##################################
+
+
+def get_backend_config(build_env, terraform_output):
+    """Returns ssm readble object provided terraform output object"""
+    try:
+        return {
+            build_env: [
+                {
+                    "var_name": "dynamodb_table",
+                    "value": terraform_output['dynamodb_table_name']['value'],
+                    "var_type": "String",
+                },
+                {
+                    "var_name": "bucket",
+                    "value": terraform_output['s3_bucket_id']['value'],
+                    "var_type": "String",
+                },
+            ]
+        }
+    except KeyError:
+        print('\nERROR: Terraform output did not contain the expected '
+              'key/value pair(s).. Exiting.. \n')
+        exit()
+    except TypeError:
+        print('\nERROR: Terraform output did not contain the expected '
+              'key/value pair(s).. Exiting.. \n')
+        exit()
+
+
+def backend_apply(tf, build_env, stage, verbose=False):
+    """Run terraform apply on the S3 backend."""
+    tf_vars = {
+        "project_name": build_env,
+        "stage": stage
+    }
+    if verbose:
+        print('\nRunning `terraform apply` against the backed for '
+              '{}\n'.format(build_env))
+        tf.apply(skip_plan=True, capture_output='True',
+                 var=tf_vars)
+    else:
+        tf.apply(skip_plan=True, var=tf_vars)
+
+
+def get_backend_bucket(build_env):
+    """Return the name of the backend bucket that is stored in SSM."""
+    ssm_obj = ssm.get_targeted_variables(build_env)
+    return ssm_obj['bucket']
+
+
+def backend_destroy(tf, build_env, stage, verbose=False):
+    """Run terraform destroy on the S3 backend."""
+    tf_vars = {
+        "project_name": build_env,
+        "stage": stage
+    }
+    if verbose:
+        print('\nEmptying the backend S3 bucket.\n')
+        s3.delete_all_objects(get_backend_bucket(build_env),
+                              verbose=verbose)
+        print('\nRunning `terraform destroy` against the backed for '
+              '{}\n'.format(build_env))
+        tf.destroy(vars=tf_vars, capture_output='True', lock='false')
+    else:
+        s3.delete_all_objects(get_backend_bucket(build_env))
+        tf.destroy(vars=tf_vars, lock='false')
+
+
+def backend_plan(tf, build_env, stage, verbose=False):
+    """Run terraform plan on the S3 backend."""
+    tf_vars = {
+        "project_name": build_env,
+        "stage": stage
+    }
+    if verbose:
+        print('\nRunning `terraform plan` against the backed for '
+              '{}\n'.format(build_env))
+        tf.plan(vars=tf_vars, capture_output='True', lock='false')
+    else:
+        tf.plan(vars=tf_vars, lock='false')
+
+
+def backend_create(tf, build_env, stage, verbose=False):
+    """Initilalize and apply the remote state backend.
+       Also sets output of remote state as variables within SSM.
+    """
+    tf_init(tf, verbose=verbose)
+    backend_apply(tf, build_env, stage, verbose)
+    ssm.set_remote_variables_from_obj(
+        get_backend_config(build_env, tf.output()), verbose=verbose
+    )
+
+
+@task(optional=['verbose'])
+def init_backend(ctx, build_env, verbose=False):
+    """Initialize the remote state backend."""
+    env_check(build_env)
+    tf = get_tf_handler(build_env, "backend_init")
+    tf_init(tf, verbose=verbose)
+
+
+@task(optional=['stage', 'verbose'])
+def apply_backend(ctx, build_env, stage="test", verbose=False):
+    """Apply the remote state backend."""
+    env_check(build_env)
+    tf = get_tf_handler(build_env, "backend_init")
+    apply_backend(tf, build_env=build_env, stage=stage, verbose=verbose)
+
+
+@task(optional=['stage', 'verbose'])
+def plan_backend(ctx, build_env, stage="test", verbose=False):
+    """Apply the remote state backend."""
+    env_check(build_env)
+    tf = get_tf_handler(build_env, "backend_init")
+    plan_backend(tf, build_env=build_env, stage=stage, verbose=verbose)
+
+
+@task(optional=['stage', 'verbose'])
+def create_backend(ctx, build_env, stage="test", verbose=False):
+    """Initialize and apply the backend."""
+    env_check(build_env)
+    tf = get_tf_handler(build_env, "backend_init")
+    backend_create(tf, build_env=build_env, stage=stage, verbose=verbose)
+
+
+@task(optional=['stage', 'verbose'])
+def destroy_backend(ctx, build_env, stage="test", verbose=False):
+    """Apply the remote state backend."""
+    env_check(build_env)
+    tf = get_tf_handler(build_env, "backend_init")
+    backend_destroy(tf, build_env=build_env, stage=stage, verbose=verbose)
+
+
+# ################################
+#
+# main module
+#
+##################################
+
+
+def get_backend_config_from_ssm(build_env, verbose=False):
+    """Return object with backend configuration values."""
+    env_check(build_env)
+    if verbose:
+        print('\nRetrieving backend configuration variables from SSM\n')
+    ssm_obj = ssm.get_targeted_variables(build_env)
+    try:
+        return {
+            "bucket": ssm_obj['bucket'],
+            "key": "terraform.tfstate",
+            "dynamodb_table": ssm_obj['dynamodb_table']
+        }
+    except KeyError:
+        print('\nERROR: key/value not found in SSM. Ensure backend has'
+              ' been initilized with `invoke create-backend '
+              '--build-env={}`\n'.format(build_env))
+        exit()
+
+
+def env_apply(tf, tf_vars, verbose=False):
+    """Apply the target environment."""
+    if verbose:
+        print('\nRunning `terraform apply` aginst the target codebuild '
+              'project\nenv_apply: passing the following vars:'
+              ' {}\n'.format(tf_vars))
+        tf.apply(skip_plan=True, capture_output='True', vars=tf_vars)
+    else:
+        tf.apply(skip_plan=True, vars=tf_vars)
+
+
+def env_destroy(tf, tf_vars, verbose=False):
+    """Destroy the target environment."""
+    if verbose:
+        print('\nRunning `terraform destroy` against the target codebuild '
+              'project.\n\ntf_destroy_env: passing the following vars:'
+              ' {}\n'.format(tf_vars))
+        tf.destroy(capture_output='True', vars=tf_vars, lock=False)
+    else:
+        tf.destroy(vars=tf_vars, lock=False)
+
+
+def env_and_backend_destroy(tf_env, tf_backend, build_env, tf_vars,
+                            verbose=False):
+    """Destroy the target environment and its backend."""
+    env_destroy(tf_env, tf_vars, verbose)
+    destroy_backend(tf_backend, build_env, stage, verbose)
+
+
+def env_destroy_all(build_env, include_backend=False, verbose=False):
+    """Destroys the target codebuild project."""
+    env_check(build_env)
+    tf_env = get_tf_handler(build_env)
+    tf_vars = ssm.get_targeted_variables(build_env)
+    if include_backend:
+        tf_backend = get_tf_handler(build_env, "backend_init")
+        env_and_backend_destroy(tf_env, tf_backend, build_env, tf_vars,
+                                verbose)
+    else:
+        env_destroy(tf=tf_env, tf_vars=tf_vars, verbose=verbose)
+
+
+def env_create(build_env, stage, verbose=False):
+    """Create the backend and environment."""
+    env_check(build_env)
+    # initialize terraform-python in the backend directory
+    tf_state = get_tf_handler(build_env, "backend_init")
+    # create the backend
+    backend_create(tf=tf_state, build_env=build_env, stage=stage,
+                   verbose=verbose)
+    # initialize terraform-python in the main project directory
+    tf_env = get_tf_handler(build_env)
+    # get the backend configuration from SSM
+    backend_config = get_backend_config_from_ssm(build_env, verbose=verbose)
+    # initialze the main project's backend
+    tf_init(tf=tf_env, backend_config=backend_config, verbose=verbose)
+    # get the main project's input variables from ssm
+    tf_vars = ssm.get_targeted_variables(build_env)
+    # run terraform apply against the main project
+    env_apply(tf=tf_env, tf_vars=tf_vars, verbose=verbose)
+
+
+@task()
+def init_env(ctx, build_env, verbose=False):
+    """Intialize the target environment via pyinvoke."""
+    env_check(build_env)
+    tf = get_tf_handler(build_env)
+    backend_config = get_backend_config_from_ssm(build_env)
+    tf_init(tf, backend_config=backend_config, verbose=verbose)
+
+
+@task()
+def apply_env(ctx, build_env, verbose=False):
+    """Apply the target environment via pyinvoke."""
+    env_check(build_env)
+    tf = get_tf_handler(build_env)
+    tf_vars = ssm.get_targeted_variables(build_env)
+    env_apply(tf, tf_vars=tf_vars, verbose=verbose)
+
+
+@task()
+def create_env(ctx, build_env, stage, verbose=False):
+    """Create the backend and environment via pyinvoke."""
+    if build_env == 'all':
+        for env in ENVIRONMENTS:
+            env_create(env, stage, verbose)
+    else:
+        env_create(build_env, stage, verbose)
+
+
+@task()
+def destroy_env(ctx, build_env, include_backend=False, verbose=False):
+    """Destroys the target codebuild project via pyinvoke."""
+    if build_env == 'all':
+        for env in ENVIRONMENTS:
+            env_destroy_all(env, include_backend, verbose)
+    else:
+        env_destroy_all(build_env, include_backend, verbose)
+
+
+# ################################
+#
+# ssm variables
+#
+##################################
+
+@task(optional=['validate', 'build_env', 'update', 'verbose'],
+      help={"validate": "[Optional] Accepts values of 'local' or 'remote'." +
+            " local = validate the file structure of varaiables.yaml " +
+            " remote = compare variables.yaml to the vales stored in AWS SSM",
+            "env": "[Optional] if provided will target a single environment." +
+            " all environments are passed by default.",
+            "update": "[Optional] Updates the AWS SSM variable values with " +
+            " variables.yaml",
+            "verbose": "[Optional] Use this flag to provide output"})
+def variables(ctx, build_env=None, update=None, validate=None, verbose=None):
+    """Update, view, or validate existing or new ssm variables."""
+    if validate == 'local':
+        if verbose:
+            print("Validating variables.yaml..")
+        ssm.local_parameter_check()
+    elif validate == 'remote':
+        if verbose:
+            print("Comparing variables.yaml values to AWS SSM values..")
+            if build_env:
+                print("Targeting build-env: {}".format(build_env))
+        print("\n")
+        ssm.compare_ssm_to_local(verbose=verbose, target_env=build_env)
+    if update:
+        if verbose:
+            print("Validating variables.yaml..")
+        ssm.set_remote_variables_from_file(verbose=verbose)


### PR DESCRIPTION
Fixes # .

Changes offered/proposed in this pull request:
- deployment of SPEL CodeBuild projects via the cli using`pyinvoke` and terraform
- python based terraform variable assignment backed by SSM
- SPEL project SSM variable manipulation via external yaml doc


* New PR Alert to: @plus3it/spel
