### PR TITLE
adds test to validate /var/run symlink on el7

### DIFF
--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -132,3 +132,9 @@ def test_timedatectl_dbus_status(host):
     log.info('stdout:\n%s', timedatectl.stdout)
     log.info('stderr:\n%s', timedatectl.stderr)
     assert timedatectl.exit_status == 0
+
+
+@pytest.mark.el7
+def test_var_run_symlink(host):
+    var_run_symlink = host.file('/var/run').linked_to
+    assert var_run_symlink == '/run'


### PR DESCRIPTION
Fixes # N/A

Changes offered/proposed in this pull request:
- check `/var/run` is a symlink to `/run` on el7

* New PR Alert to: @plus3it/spel
