### PR TITLE
Ensures python3 symlink exists when python3 is installed

### DIFF
--- a/spel/scripts/amigen7-build.sh
+++ b/spel/scripts/amigen7-build.sh
@@ -21,6 +21,7 @@ EXTRARPMS="${SPEL_EXTRARPMS}"
 FIPSDISABLE="${SPEL_FIPSDISABLE}"
 VGNAME="${SPEL_VGNAME:-VolGroup00}"
 
+PYTHON3_BIN="/usr/bin/python3.6"
 ELBUILD="/tmp/el-build"
 AMIUTILS="/tmp/ami-utils"
 
@@ -233,6 +234,12 @@ bash -eux -o pipefail "${ELBUILD}"/CleanChroot.sh
 
 echo "Executing PreRelabel.sh"
 bash -eux -o pipefail "${ELBUILD}"/PreRelabel.sh
+
+if [[ -x "${CHROOT}${PYTHON3_BIN}" ]]
+then
+    echo "Ensuring python3 symlink exists"
+    chroot "$CHROOT" ln -sf "$PYTHON3_BIN" /usr/bin/python3
+fi
 
 if [[ "${CLOUDPROVIDER}" == "azure" ]]
 then

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -113,6 +113,12 @@ def test_python3_installed(host, name):
 
 
 @pytest.mark.el7
+def test_python3_symlink(host):
+    python3_symlink = host.file('/usr/bin/python3').linked_to
+    assert python3_symlink == '/usr/bin/python3.6'
+
+
+@pytest.mark.el7
 def test_timedatectl_dbus_status(host):
     cmd = 'timedatectl'
     timedatectl = host.run(cmd)
@@ -125,3 +131,4 @@ def test_timedatectl_dbus_status(host):
 def test_var_run_symlink(host):
     var_run_symlink = host.file('/var/run').linked_to
     assert var_run_symlink == '/run'
+


### PR DESCRIPTION
The python3.6 rpm from epel is not currently installing the python3 symlink.

* New PR Alert to: @plus3it/spel
