### PR TITLE
Avoids overwriting python3 symlink if already installed by rpm

### DIFF
--- a/spel/scripts/amigen7-build.sh
+++ b/spel/scripts/amigen7-build.sh
@@ -22,6 +22,7 @@ FIPSDISABLE="${SPEL_FIPSDISABLE}"
 VGNAME="${SPEL_VGNAME:-VolGroup00}"
 
 PYTHON3_BIN="/usr/bin/python3.6"
+PYTHON3_LINK="/usr/bin/python3"
 ELBUILD="/tmp/el-build"
 AMIUTILS="/tmp/ami-utils"
 
@@ -235,10 +236,10 @@ bash -eux -o pipefail "${ELBUILD}"/CleanChroot.sh
 echo "Executing PreRelabel.sh"
 bash -eux -o pipefail "${ELBUILD}"/PreRelabel.sh
 
-if [[ -x "${CHROOT}${PYTHON3_BIN}" ]]
+if [[ -x "${CHROOT}${PYTHON3_BIN}" && ! -s "${CHROOT}${PYTHON3_LINK}" ]]
 then
     echo "Ensuring python3 symlink exists"
-    chroot "$CHROOT" ln -sf "$PYTHON3_BIN" /usr/bin/python3
+    chroot "$CHROOT" ln -sf "$PYTHON3_BIN" "$PYTHON3_LINK"
 fi
 
 if [[ "${CLOUDPROVIDER}" == "azure" ]]


### PR DESCRIPTION
Had a bit of feedback to address on the prior patch...

* New PR Alert to: @plus3it/spel
