### PR TITLE
Add Support for XFS-Enabled Images

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ defaults):
     "spel_epel7release": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm",
     "spel_epelrepo": "epel",
     "spel_extrarpms": "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm,python36",
+    "spel_fstype": "ext4",
     "spel_identifier": "",
     "spel_version": "",
     "ssh_interface": "public_dns",
@@ -293,6 +294,7 @@ defaults):
 | `spel_epel7release`     | URL to the release RPM for the [EPEL 7][10] repo                  |
 | `spel_epelrepo`         | Name of the epel repo (if different than "epel")                  |
 | `spel_extrarpms`        | Comma-separated list of extra package/@group names to pass to yum |
+| `spel_fstype`           | Filesystem-type to use for root filesystems. Default is `ext4`. Other supported options are `ext3` and `xfs` |
 
 All other variables in the `packer` template map directly to variables defined
 in the `packer` docs for the [amazon-ebs builder][11] or the [virtualbox-iso
@@ -306,6 +308,8 @@ The Minimal Linux `packer` template includes the following builders:
 |----------------------------------|-------------------------------------------------------------|
 | `minimal-centos-7-hvm`         | amazon-ebs builder that results in a minimal CentOS 7 HVM AMI |
 | `minimal-rhel-7-hvm`           | amazon-ebs builder that results in a minimal RHEL 7 HVM AMI   |
+| `minimal-centos-7-hvm-xfs`     | amazon-ebs builder that results in a minimal CentOS 7 HVM AMI with XFS filesystems |
+| `minimal-rhel-7-hvm-xfs`       | amazon-ebs builder that results in a minimal RHEL 7 HVM AMI with XFS filesystems |
 | `minimal-centos-7-azure-vhd`   | azure-arm builder that results in a minimal CentOS 7 VHD      |
 | `minimal-centos-7-azure-image` | azure-arm builder that results in a minimal CentOS 7 Image    |
 

--- a/README.md
+++ b/README.md
@@ -277,23 +277,23 @@ defaults):
 }
 ```
 
-| Variable Name           | Description                                                       |
-|-------------------------|-------------------------------------------------------------------|
-| `vagrantcloud_username` | Username in Hashicorp Vagrant Cloud                               |
-| `vagrantcloud_token`    | Authentication token for Vagrant Cloud (env: VAGRANTCLOUD_TOKEN)  |
-| `security_group_cidr`   | CIDR to restrict security group created by Packer                 |
-| `spel_identifier`       | Project ID to associate to the resulting images                   |
-| `spel_version`          | Version to assign to the resulting image(s)                       |
-| `spel_amigen7source`    | URL to the git repository for the `AMIGen7` project               |
-| `spel_amiutilsource`    | URL to the git repository for the `Lx-GetAMI-Utils` project       |
-| `spel_awsclisource`     | URL to the site hosting the file `awscli-bundle.zip`              |
-| `spel_customreporpm7`   | URL to a custom release RPM containing base repos for EL7         |
-| `spel_customreponame7`  | Name(s) of the custom yum repos (* or comma-separated) for EL7    |
-| `spel_disablefips`      | Flag that disables FIPS in EL7 AMIs                               |
-| `spel_desc_url`         | URL to detailed description of AMI                                |
-| `spel_epel7release`     | URL to the release RPM for the [EPEL 7][10] repo                  |
-| `spel_epelrepo`         | Name of the epel repo (if different than "epel")                  |
-| `spel_extrarpms`        | Comma-separated list of extra package/@group names to pass to yum |
+| Variable Name           | Description                                                                                                  |
+|-------------------------|--------------------------------------------------------------------------------------------------------------|
+| `vagrantcloud_username` | Username in Hashicorp Vagrant Cloud                                                                          |
+| `vagrantcloud_token`    | Authentication token for Vagrant Cloud (env: VAGRANTCLOUD_TOKEN)                                             |
+| `security_group_cidr`   | CIDR to restrict security group created by Packer                                                            |
+| `spel_identifier`       | Project ID to associate to the resulting images                                                              |
+| `spel_version`          | Version to assign to the resulting image(s)                                                                  |
+| `spel_amigen7source`    | URL to the git repository for the `AMIGen7` project                                                          |
+| `spel_amiutilsource`    | URL to the git repository for the `Lx-GetAMI-Utils` project                                                  |
+| `spel_awsclisource`     | URL to the site hosting the file `awscli-bundle.zip`                                                         |
+| `spel_customreporpm7`   | URL to a custom release RPM containing base repos for EL7                                                    |
+| `spel_customreponame7`  | Name(s) of the custom yum repos (* or comma-separated) for EL7                                               |
+| `spel_disablefips`      | Flag that disables FIPS in EL7 AMIs                                                                          |
+| `spel_desc_url`         | URL to detailed description of AMI                                                                           |
+| `spel_epel7release`     | URL to the release RPM for the [EPEL 7][10] repo                                                             |
+| `spel_epelrepo`         | Name of the epel repo (if different than "epel")                                                             |
+| `spel_extrarpms`        | Comma-separated list of extra package/@group names to pass to yum                                            |
 | `spel_fstype`           | Filesystem-type to use for root filesystems. Default is `ext4`. Other supported options are `ext3` and `xfs` |
 
 All other variables in the `packer` template map directly to variables defined
@@ -304,14 +304,14 @@ builder][18] or the [vmware-iso builder][14].
 
 The Minimal Linux `packer` template includes the following builders:
 
-| Builder Name                     | Description                                                 |
-|----------------------------------|-------------------------------------------------------------|
-| `minimal-centos-7-hvm`         | amazon-ebs builder that results in a minimal CentOS 7 HVM AMI |
-| `minimal-rhel-7-hvm`           | amazon-ebs builder that results in a minimal RHEL 7 HVM AMI   |
-| `minimal-centos-7-hvm-xfs`     | amazon-ebs builder that results in a minimal CentOS 7 HVM AMI with XFS filesystems |
-| `minimal-rhel-7-hvm-xfs`       | amazon-ebs builder that results in a minimal RHEL 7 HVM AMI with XFS filesystems |
-| `minimal-centos-7-azure-vhd`   | azure-arm builder that results in a minimal CentOS 7 VHD      |
-| `minimal-centos-7-azure-image` | azure-arm builder that results in a minimal CentOS 7 Image    |
+| Builder Name                     | Description                                                                        |
+|----------------------------------|------------------------------------------------------------------------------------|
+| `minimal-centos-7-hvm`           | amazon-ebs builder that results in a minimal CentOS 7 HVM AMI                      |
+| `minimal-rhel-7-hvm`             | amazon-ebs builder that results in a minimal RHEL 7 HVM AMI                        |
+| `minimal-centos-7-hvm-xfs`       | amazon-ebs builder that results in a minimal CentOS 7 HVM AMI with XFS filesystems |
+| `minimal-rhel-7-hvm-xfs`         | amazon-ebs builder that results in a minimal RHEL 7 HVM AMI with XFS filesystems   |
+| `minimal-centos-7-azure-vhd`     | azure-arm builder that results in a minimal CentOS 7 VHD                           |
+| `minimal-centos-7-azure-image`   | azure-arm builder that results in a minimal CentOS 7 Image                         |
 
 ### Minimal Linux Packer Post-Provisioners
 

--- a/spel/minimal-linux.json
+++ b/spel/minimal-linux.json
@@ -63,7 +63,7 @@
         {
             "ami_description": "STIG-partitioned [*NOT HARDENED*], LVM-enabled, XFS-formatted, \"minimal\" CentOS 7 AMI, with updates through {{ isotime \"2006-01-02\" }}. Default username `maintuser`. See {{ user `spel_desc_url` }}.",
             "ami_groups": "{{ user `ami_groups` }}",
-            "ami_name": "{{ user `spel_identifier` }}-minimal-centos-7-hvm-{{ user `spel_version` }}.x86_64-gp2-xfs",
+            "ami_name": "{{ user `spel_identifier` }}-{{ sed \"s/-xfs//\" build_name }}-{{ user `spel_version` }}.x86_64-gp2-xfs",
             "ami_regions": "{{ user `ami_regions` }}",
             "ami_users": "{{ user `ami_users` }}",
             "associate_public_ip_address": true,
@@ -129,7 +129,7 @@
         {
             "ami_description": "STIG-partitioned [*NOT HARDENED*], LVM-enabled, XFS-formatted, \"minimal\" RHEL 7 AMI (yum and license chargeback included) with updates through {{ isotime \"2006-01-02\" }}. Default username `maintuser`. See {{ user `spel_desc_url` }}.",
             "ami_groups": "{{ user `ami_groups` }}",
-            "ami_name": "{{ user `spel_identifier` }}-minimal-rhel-7-hvm-{{ user `spel_version` }}.x86_64-gp2-xfs",
+            "ami_name": "{{ user `spel_identifier` }}-{{ sed \"s/-xfs//\" build_name }}-{{ user `spel_version` }}.x86_64-gp2-xfs",
             "ami_regions": "{{ user `ami_regions` }}",
             "ami_users": "{{ user `ami_users` }}",
             "associate_public_ip_address": true,

--- a/spel/minimal-linux.json
+++ b/spel/minimal-linux.json
@@ -63,7 +63,7 @@
         {
             "ami_description": "STIG-partitioned [*NOT HARDENED*], LVM-enabled, XFS-formatted, \"minimal\" CentOS 7 AMI, with updates through {{ isotime \"2006-01-02\" }}. Default username `maintuser`. See {{ user `spel_desc_url` }}.",
             "ami_groups": "{{ user `ami_groups` }}",
-            "ami_name": "{{ user `spel_identifier` }}-{{ build_name }}-{{ user `spel_version` }}.x86_64-gp2-xfs",
+            "ami_name": "{{ user `spel_identifier` }}-minimal-centos-7-hvm-{{ user `spel_version` }}.x86_64-gp2-xfs",
             "ami_regions": "{{ user `ami_regions` }}",
             "ami_users": "{{ user `ami_users` }}",
             "associate_public_ip_address": true,
@@ -129,7 +129,7 @@
         {
             "ami_description": "STIG-partitioned [*NOT HARDENED*], LVM-enabled, XFS-formatted, \"minimal\" RHEL 7 AMI (yum and license chargeback included) with updates through {{ isotime \"2006-01-02\" }}. Default username `maintuser`. See {{ user `spel_desc_url` }}.",
             "ami_groups": "{{ user `ami_groups` }}",
-            "ami_name": "{{ user `spel_identifier` }}-{{ build_name }}-{{ user `spel_version` }}.x86_64-gp2-xfs",
+            "ami_name": "{{ user `spel_identifier` }}-minimal-rhel-7-hvm-{{ user `spel_version` }}.x86_64-gp2-xfs",
             "ami_regions": "{{ user `ami_regions` }}",
             "ami_users": "{{ user `ami_users` }}",
             "associate_public_ip_address": true,
@@ -283,7 +283,9 @@
             ],
             "only": [
                 "minimal-centos-7-hvm",
+                "minimal-centos-7-hvm-xfs",
                 "minimal-rhel-7-hvm",
+                "minimal-rhel-7-hvm-xfs",
                 "minimal-centos-7-azure-vhd",
                 "minimal-centos-7-azure-image"
             ],
@@ -299,7 +301,9 @@
             ],
             "only": [
                 "minimal-centos-7-hvm",
+                "minimal-centos-7-hvm-xfs",
                 "minimal-rhel-7-hvm",
+                "minimal-rhel-7-hvm-xfs",
                 "minimal-centos-7-azure-vhd",
                 "minimal-centos-7-azure-image"
             ],
@@ -327,7 +331,9 @@
             "execute_command": "{{ .Vars }} sudo -E /bin/sh '{{ .Path }}'",
             "only": [
                 "minimal-centos-7-hvm",
-                "minimal-rhel-7-hvm"
+                "minimal-centos-7-hvm-xfs",
+                "minimal-rhel-7-hvm",
+                "minimal-rhel-7-hvm-xfs"
             ],
             "scripts": [
                 "{{ template_dir }}/scripts/amigen7-build.sh"

--- a/spel/minimal-linux.json
+++ b/spel/minimal-linux.json
@@ -61,6 +61,39 @@
             "user_data_file": "{{ template_dir }}/userdata/tmpfsroot-el7.cloud"
         },
         {
+            "ami_description": "STIG-partitioned [*NOT HARDENED*], LVM-enabled, XFS-formatted, \"minimal\" CentOS 7 AMI, with updates through {{ isotime \"2006-01-02\" }}. Default username `maintuser`. See {{ user `spel_desc_url` }}.",
+            "ami_groups": "{{ user `ami_groups` }}",
+            "ami_name": "{{ user `spel_identifier` }}-{{ build_name }}-{{ user `spel_version` }}.x86_64-gp2-xfs",
+            "ami_regions": "{{ user `ami_regions` }}",
+            "ami_users": "{{ user `ami_users` }}",
+            "associate_public_ip_address": true,
+            "communicator": "ssh",
+            "ena_support": true,
+            "force_deregister": "{{ user `ami_force_deregister` }}",
+            "instance_type": "m4.xlarge",
+            "launch_block_device_mappings": [
+                {
+                    "delete_on_termination": true,
+                    "device_name": "/dev/sda1",
+                    "volume_size": 20,
+                    "volume_type": "gp2"
+                }
+            ],
+            "name": "minimal-centos-7-hvm-xfs",
+            "region": "{{ user `aws_region` }}",
+            "source_ami": "{{ user `source_ami_centos7_hvm` }}",
+            "sriov_support": true,
+            "ssh_interface": "{{ user `ssh_interface` }}",
+            "ssh_port": 122,
+            "ssh_pty": true,
+            "ssh_timeout": "60m",
+            "ssh_username": "spel",
+            "subnet_id": "{{ user `subnet_id` }}",
+            "temporary_security_group_source_cidr": "{{ user `security_group_cidr` }}",
+            "type": "amazon-ebs",
+            "user_data_file": "{{ template_dir }}/userdata/tmpfsroot-el7.cloud"
+        },
+        {
             "ami_description": "STIG-partitioned [*NOT HARDENED*], LVM-enabled, \"minimal\" RHEL 7 AMI (yum and license chargeback included) with updates through {{ isotime \"2006-01-02\" }}. Default username `maintuser`. See {{ user `spel_desc_url` }}.",
             "ami_groups": "{{ user `ami_groups` }}",
             "ami_name": "{{ user `spel_identifier` }}-{{ build_name }}-{{ user `spel_version` }}.x86_64-gp2",
@@ -80,6 +113,39 @@
                 }
             ],
             "name": "minimal-rhel-7-hvm",
+            "region": "{{ user `aws_region` }}",
+            "source_ami": "{{ user `source_ami_rhel7_hvm` }}",
+            "sriov_support": true,
+            "ssh_interface": "{{ user `ssh_interface` }}",
+            "ssh_port": 122,
+            "ssh_pty": true,
+            "ssh_timeout": "60m",
+            "ssh_username": "spel",
+            "subnet_id": "{{ user `subnet_id` }}",
+            "temporary_security_group_source_cidr": "{{ user `security_group_cidr` }}",
+            "type": "amazon-ebs",
+            "user_data_file": "{{ template_dir }}/userdata/tmpfsroot-el7.cloud"
+        },
+        {
+            "ami_description": "STIG-partitioned [*NOT HARDENED*], LVM-enabled, XFS-formatted, \"minimal\" RHEL 7 AMI (yum and license chargeback included) with updates through {{ isotime \"2006-01-02\" }}. Default username `maintuser`. See {{ user `spel_desc_url` }}.",
+            "ami_groups": "{{ user `ami_groups` }}",
+            "ami_name": "{{ user `spel_identifier` }}-{{ build_name }}-{{ user `spel_version` }}.x86_64-gp2-xfs",
+            "ami_regions": "{{ user `ami_regions` }}",
+            "ami_users": "{{ user `ami_users` }}",
+            "associate_public_ip_address": true,
+            "communicator": "ssh",
+            "ena_support": true,
+            "force_deregister": "{{ user `ami_force_deregister` }}",
+            "instance_type": "t2.large",
+            "launch_block_device_mappings": [
+                {
+                    "delete_on_termination": true,
+                    "device_name": "/dev/sda1",
+                    "volume_size": 20,
+                    "volume_type": "gp2"
+                }
+            ],
+            "name": "minimal-rhel-7-hvm-xfs",
             "region": "{{ user `aws_region` }}",
             "source_ami": "{{ user `source_ami_rhel7_hvm` }}",
             "sriov_support": true,
@@ -255,6 +321,7 @@
                 "SPEL_EPELRELEASE={{ user `spel_epel7release` }}",
                 "SPEL_EPELREPO={{ user `spel_epelrepo` }}",
                 "SPEL_EXTRARPMS={{ user `spel_extrarpms` }}",
+                "SPEL_FSTYPE={{ user `spel_fstype` }}",
                 "SPEL_VGNAME=VolGroup00"
             ],
             "execute_command": "{{ .Vars }} sudo -E /bin/sh '{{ .Path }}'",
@@ -283,6 +350,7 @@
                 "SPEL_EPELRELEASE={{ user `spel_epel7release` }}",
                 "SPEL_EPELREPO={{ user `spel_epelrepo` }}",
                 "SPEL_EXTRARPMS={{ user `spel_extrarpms` }}",
+                "SPEL_FSTYPE={{ user `spel_fstype` }}",
                 "SPEL_VGNAME=VolGroup00"
             ],
             "execute_command": "{{ .Vars }} sudo -E /bin/sh '{{ .Path }}'",
@@ -348,6 +416,7 @@
         "spel_epel7release": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm",
         "spel_epelrepo": "epel",
         "spel_extrarpms": "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm,python36",
+        "spel_fstype": "ext4",
         "spel_identifier": "",
         "spel_version": "",
         "ssh_interface": "public_dns",

--- a/spel/scripts/amigen7-build.sh
+++ b/spel/scripts/amigen7-build.sh
@@ -19,6 +19,7 @@ EPELRELEASE="${SPEL_EPELRELEASE:-https://dl.fedoraproject.org/pub/epel/epel-rele
 EPELREPO="${SPEL_EPELREPO:-epel}"
 EXTRARPMS="${SPEL_EXTRARPMS}"
 FIPSDISABLE="${SPEL_FIPSDISABLE}"
+FSTYPE="${SPEL_FSTYPE:-ext4}"
 VGNAME="${SPEL_VGNAME:-VolGroup00}"
 
 PYTHON3_BIN="/usr/bin/python3.6"
@@ -178,10 +179,10 @@ do
 done
 
 echo "Executing DiskSetup.sh"
-bash -eux -o pipefail "${ELBUILD}"/DiskSetup.sh -b "${BOOTLABEL}" -v "${VGNAME}" -d "${DEVNODE}"
+bash -eux -o pipefail "${ELBUILD}"/DiskSetup.sh -b "${BOOTLABEL}" -v "${VGNAME}" -d "${DEVNODE}" -f "${FSTYPE}"
 
 echo "Executing MkChrootTree.sh"
-bash -eux -o pipefail "${ELBUILD}"/MkChrootTree.sh "${DEVNODE}"
+bash -eux -o pipefail "${ELBUILD}"/MkChrootTree.sh "${DEVNODE}" "${FSTYPE}"
 
 echo "Executing MkTabs.sh"
 bash -eux -o pipefail "${ELBUILD}"/MkTabs.sh "${DEVNODE}"


### PR DESCRIPTION
Adds ability to create images using XFS for the root filesystems.

Updates README to include relevant new options in documentation.

Includes AMI builders for RHEL7+xfs and CentOS7+xfs.

Note<sup>1</sup>: I'm not _super_ chuffed with how I had to construct the `ami_name` for these builders. I wanted to have `xfs` be the ending token in the name, as that seemed the least-disruptive way to extend the existing naming. Unfortunately, because the builder `name`s also contain `xfs` in them, I had to hardcode what was previously a variable-reference so as to avoid the `xfs` token being present twice in the registered AMI name. If there's a better way, please let me know.

Note<sup>2</sup>: With the current method for activating the `spel_fstype`, _all_ images in a batch get buile with the same `spel_fstype`. In order to build images for multiple `spel_fstype`s, it will be necessary to do multiple packer invocations. If there's a suggestion for a method that avoids this need for per `spel_fstype` invocations, please let me know.