### PR TITLE
Fix Amazon RPM Regex

### DIFF
--- a/spel/scripts/amigen7-build.sh
+++ b/spel/scripts/amigen7-build.sh
@@ -177,7 +177,7 @@ chmod +x "${ELBUILD}"/*.sh
 echo "Cloning source of the AMI utils project"
 git clone "${AMIUTILSSOURCE}" "${AMIUTILS}" --depth 1
 
-for RPM in "${AMIUTILS}"/*.el7.noarch.rpm
+for RPM in "${AMIUTILS}"/*.el7.*.rpm
 do
     echo "Creating link for ${RPM} in ${ELBUILD}/AWSpkgs/"
     ln "${RPM}" "${ELBUILD}"/AWSpkgs/


### PR DESCRIPTION
Prior regex fails to install some packages from the Lx-GetAMI-Utils project. This modification ensures that all relevant packages from the Lx-GetAMI-Utils project are installed.

Note: issue discovered while testing the AMZN Linux 2 (20190612) updates for the Lx-GetAMI-Utils project.