### PR TITLE
Fix python 3.x RPM install

### DIFF
--- a/spel/minimal-linux.json
+++ b/spel/minimal-linux.json
@@ -358,7 +358,7 @@
         "spel_disablefips": "",
         "spel_epel7release": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm",
         "spel_epelrepo": "epel",
-        "spel_extrarpms": "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm,python36",
+        "spel_extrarpms": "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm,python3",
         "spel_identifier": "",
         "spel_version": "",
         "ssh_interface": "public_dns",


### PR DESCRIPTION
Prevents errors related to trying to install a deprecated package.

Note: issue not previously noticed in testing because the testing-environment explicitly overrides the value of `spel_extrarpms`