### PR TITLE
Add support for AMIgen7's -g and -m Flagged-options

### DIFF
--- a/spel/minimal-linux.json
+++ b/spel/minimal-linux.json
@@ -241,8 +241,10 @@
         },
         {
             "environment_vars": [
-                "SPEL_AMIGENSOURCE={{ user `spel_amigen7source` }}",
                 "SPEL_AMIGENBRANCH={{ user `spel_amigen7branch` }}",
+                "SPEL_AMIGENMANFST={{ user `spel_amigen7manfst` }}",
+                "SPEL_AMIGENPKGGRP={{ user `spel_amigen7pkggrp` }}",
+                "SPEL_AMIGENSOURCE={{ user `spel_amigen7source` }}",
                 "SPEL_AMIGENSTORLAY={{ user `spel_amigen7storlay` }}",
                 "SPEL_AMIUTILSSOURCE={{ user `spel_amiutilsource` }}",
                 "SPEL_AWSCLISOURCE={{ user `spel_awsclisource` }}",
@@ -348,6 +350,8 @@
         "source_ami_centos7_hvm": "ami-090b9dabe1c9f40b3",
         "source_ami_rhel7_hvm": "ami-0394fe9914b475c53",
         "spel_amigen7branch": "master",
+        "spel_amigen7manfst": "",
+        "spel_amigen7pkggrp": "core",
         "spel_amigen7source": "https://github.com/plus3it/AMIgen7.git",
         "spel_amigen7storlay": "/:rootVol:4,swap:swapVol:2,/home:homeVol:1,/var:varVol:2,/var/log:logVol:2,/var/log/audit:auditVol:100%FREE",
         "spel_amiutilsource": "https://github.com/ferricoxide/Lx-GetAMI-Utils.git",

--- a/spel/scripts/amigen7-build.sh
+++ b/spel/scripts/amigen7-build.sh
@@ -6,6 +6,8 @@
 ##############################################################################
 AMIGENSOURCE="${SPEL_AMIGENSOURCE:-https://github.com/plus3it/AMIgen7.git}"
 AMIGENBRANCH="${SPEL_AMIGENBRANCH:-master}"
+AMIGENMANFST="${SPEL_AMIGENMANFST}"
+AMIGENPKGGRP="${SPEL_AMIGENPKGGRP:-core}"
 AMIGENSTORLAY="${SPEL_AMIGENSTORLAY:-/:rootVol:4,swap:swapVol:2,/home:homeVol:1,/var:varVol:2,/var/log:logVol:2,/var/log/audit:auditVol:100%FREE}"
 AMIUTILSSOURCE="${SPEL_AMIUTILSSOURCE:-https://github.com/ferricoxide/Lx-GetAMI-Utils.git}"
 AWSCLISOURCE="${SPEL_AWSCLISOURCE:-https://s3.amazonaws.com/aws-cli/awscli-bundle.zip}"
@@ -205,6 +207,16 @@ bash -eux -o pipefail "${ELBUILD}"/MkChrootTree.sh "${DEVNODE}" "" "${AMIGENSTOR
 echo "Executing MkTabs.sh"
 bash -eux -o pipefail "${ELBUILD}"/MkTabs.sh "${DEVNODE}"
 
+# Construct the cli option string for alternate-manifest
+CLIOPT_ALTMANIFEST=""
+if [[ -n ${AMIGENMANFST} ]]
+then
+   CLIOPT_ALTMANIFEST="( -m "${AMIGENMANFST}" )"
+else
+   CLIOPT_ALTMANIFEST="( -g "${AMIGENPKGGRP}" )"
+fi
+
+
 # Construct the cli option string for extra rpms
 CLIOPT_EXTRARPMS=""
 if [[ -n "${EXTRARPMS}" ]]
@@ -220,7 +232,7 @@ then
 fi
 
 echo "Executing ChrootBuild.sh"
-bash -eux -o pipefail "${ELBUILD}"/ChrootBuild.sh "${CLIOPT_CUSTOMREPO[@]}" "${CLIOPT_EXTRARPMS[@]}"
+bash -eux -o pipefail "${ELBUILD}"/ChrootBuild.sh "${CLIOPT_CUSTOMREPO[@]}" "${CLIOPT_EXTRARPMS[@]}" "${CLIOPT_ALTMANIFEST[@]}"
 
 if [[ "${CLOUDPROVIDER}" == "aws" ]]
 then

--- a/spel/scripts/amigen7-build.sh
+++ b/spel/scripts/amigen7-build.sh
@@ -211,9 +211,11 @@ bash -eux -o pipefail "${ELBUILD}"/MkTabs.sh "${DEVNODE}"
 CLIOPT_ALTMANIFEST=""
 if [[ -n ${AMIGENMANFST} ]]
 then
-   CLIOPT_ALTMANIFEST="( -m "${AMIGENMANFST}" )"
+   CLIOPT_ALTMANIFEST=( -m "${AMIGENMANFST}" )
+   echo "Sending manifest-option '${CLIOPT_ALTMANIFEST[*]}'"
 else
-   CLIOPT_ALTMANIFEST="( -g "${AMIGENPKGGRP}" )"
+   CLIOPT_ALTMANIFEST=( -g "${AMIGENPKGGRP}" )
+   echo "Sending manifest-option '${CLIOPT_ALTMANIFEST[*]}'"
 fi
 
 


### PR DESCRIPTION
Closes #380 

Validated using activators for `-g core` and `-m /path/to/GnomeDesktop.pkgs`. 

**Note:** Experienced failures with `-g <NOT_CORE>`. However, the failure is not due to issues within spel. The issues will need to addressed in AMIgen7 (see plus3it/AMIgen7#87), directly.