### PR TITLE
Updates test for the awscli pin to look for "true"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ SPEL_CUSTOMREPORPM7 ?= https://dl.fedoraproject.org/pub/epel/epel-release-latest
 SPEL_DEVNODE ?= /dev/nvme0n1
 SPEL_EPELREPO ?= epel
 SPEL_EXTRARPMS ?= https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm,python36
+SPEL_PIN_AWSCLI_BUNDLE ?= true
 SOURCE_AMI_CENTOS7_HVM ?= ami-090b9dabe1c9f40b3
 SOURCE_AMI_RHEL7_HVM ?= ami-0394fe9914b475c53
 SSH_INTERFACE ?= public_dns
@@ -41,8 +42,8 @@ $(shell mkdir -p ".spel/${SPEL_VERSION}")
 PACKER_LOG_PATH := .spel/${SPEL_VERSION}/packer.log
 endif
 
-# Check if $SPEL_PIN_AWSCLI_BUNDLE is not null
-ifdef SPEL_PIN_AWSCLI_BUNDLE
+# Check if $SPEL_PIN_AWSCLI_BUNDLE is 'true'
+ifeq ($(SPEL_PIN_AWSCLI_BUNDLE),true)
 AWSCLI_PIN=$(shell grep aws-cli requirements/aws-cli.txt)
 ifndef AWSCLI_PIN
 $(error AWSCLI_PIN is not set: ${.SHELLSTATUS})


### PR DESCRIPTION
Was running into an issue with codebuild, where it cannot remove an
env in an override. So it was impossible to unset the env. By changing
the test to explicitly require a "true" value, it is easy to toggle
this option by setting any other value.
