### PR TITLE
Fix broken references in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,9 +497,9 @@ packer build \
 [31]: https://github.com/ferricoxide/AMIgen7
 [32]: https://github.com/plus3it/AMIgen7/blob/master/Docs/README_CustomPartitioning.md
 [33]: https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2
-* [openstack_allow_insecure][34]: https://www.packer.io/docs/builders/openstack#insecure
-* [openstack_flavor_name][35]: https://www.packer.io/docs/builders/openstack#flavor
-* [openstack_floating_ip_network_name][36]: https://www.packer.io/docs/builders/openstack#floating_ip_network
-* [openstack_network_id][37]: https://www.packer.io/docs/builders/openstack#networks
-* [openstack_security_group_name][38]: https://www.packer.io/docs/builders/openstack#security_groups
-* [openstack_source_image_name][39]: https://www.packer.io/docs/builders/openstack#source_image_name
+[34]: https://www.packer.io/docs/builders/openstack#insecure
+[35]: https://www.packer.io/docs/builders/openstack#flavor
+[36]: https://www.packer.io/docs/builders/openstack#floating_ip_network
+[37]: https://www.packer.io/docs/builders/openstack#networks
+[38]: https://www.packer.io/docs/builders/openstack#security_groups
+[39]: https://www.packer.io/docs/builders/openstack#source_image_name


### PR DESCRIPTION
Changes offered/proposed in this pull request:
- In my last PR, I added some links to Packer's OpenStack documentation.  Unfortunately, I did some copy/pasting and didn't clean up properly, so the links were broken, and there were some unintended bullets added to the tail of the README.md.  This PR fixes that.  Sorry about that!

* New PR Alert to: @plus3it/spel
