### PR TITLE
Fix broken AMI links in readme; added git ignores for local builds a…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,11 @@ packer_cache
 __pycache__
 *vendor/
 *.terraform/
+.idea
+
+# =========================
+# Local Vagrant build output
+# =========================
+*.box
+spel/output*/*
+spel/output*/*/

--- a/.gitignore
+++ b/.gitignore
@@ -59,10 +59,3 @@ __pycache__
 *vendor/
 *.terraform/
 .idea
-
-# =========================
-# Local Vagrant build output
-# =========================
-*.box
-spel/output*/*
-spel/output*/*/

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ These EL6 images were created with the help of the [`AMIgen6`][8] project.
 [1019]: <https://console.aws.amazon.com/ec2/v2/home?region=us-west-2#Images:visibility=public-images;ownerAlias=701759196663;name=spel-minimal-centos-6-hvm-.*x86_64-gp2;sort=desc:creationDate>
 [1020]: <https://console.amazonaws-us-gov.com/ec2/v2/home?region=us-gov-west-1#Images:visibility=public-images;ownerAlias=039368651566;name=spel-minimal-rhel-7-hvm-.*x86_64-gp2;sort=desc:creationDate>
 [1021]: <https://console.amazonaws-us-gov.com/ec2/v2/home?region=us-gov-west-1#Images:visibility=public-images;ownerAlias=039368651566;name=spel-minimal-rhel-6-hvm-.*x86_64-gp2;sort=desc:creationDate>
-[1022]: <https://console.amazonaws-us-gov.com/ec2/v2/home?region=us-gov-west-1#Images:visibility=public-images;ownerAlias=039368651566;name=spel-minimal-centos-7-hvm-*x86_64-gp2;sort=desc:creationDate>
-[1023]: <https://console.amazonaws-us-gov.com/ec2/v2/home?region=us-gov-west-1#Images:visibility=public-images;ownerAlias=039368651566;name=spel-minimal-centos-6-pvm-*x86_64-gp2;sort=desc:creationDate>
-[1024]: <https://console.amazonaws-us-gov.com/ec2/v2/home?region=us-gov-west-1#Images:visibility=public-images;ownerAlias=039368651566;name=spel-minimal-centos-6-hvm-*x86_64-gp2;sort=desc:creationDate>
+[1022]: <https://console.amazonaws-us-gov.com/ec2/v2/home?region=us-gov-west-1#Images:visibility=public-images;ownerAlias=039368651566;name=spel-minimal-centos-7-hvm-.*x86_64-gp2;sort=desc:creationDate>
+[1023]: <https://console.amazonaws-us-gov.com/ec2/v2/home?region=us-gov-west-1#Images:visibility=public-images;ownerAlias=039368651566;name=spel-minimal-centos-6-pvm-.*x86_64-gp2;sort=desc:creationDate>
+[1024]: <https://console.amazonaws-us-gov.com/ec2/v2/home?region=us-gov-west-1#Images:visibility=public-images;ownerAlias=039368651566;name=spel-minimal-centos-6-hvm-.*x86_64-gp2;sort=desc:creationDate>
 
 [2000]: <https://app.vagrantup.com/plus3it/boxes/spel-minimal-centos-6>
 [2001]: <https://app.vagrantup.com/plus3it/boxes/spel-minimal-centos-7>


### PR DESCRIPTION
…nd JetBrains IDEs

Fixes # .

Noticed that the links to the CentOS AMIs where not turning up any results. 

Changes offered/proposed in this pull request:
- Added ignores for JetBrains IDEs
- We can't/don't use VirtualBox, but the VmWare box on Vagrant Hub is no longer being built. I have a local branch where I've added code to build it locally with Packer, but I need to ignore the outputs. I saw where there is some cleanup for those artifacts that has been added in, but the extra git-ignores shouldn't effect that.
- 

* New PR Alert to: @plus3it/spel
