### PR TITLE
Uses dependabot/mergify to auto-update and test new packer versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 version: 2
 updates:
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
 - package-ecosystem: pip
   directory: "/"
   schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM hashicorp/packer:1.6.5

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 SHELL := /bin/bash
 
 AWS_EC2_INSTANCE_TYPE ?= t3.2xlarge
-PACKER_ZIP ?= https://releases.hashicorp.com/packer/1.4.5/packer_1.4.5_linux_amd64.zip
+PACKER_VERSION ?= $(shell grep 'FROM hashicorp/packer' Dockerfile 2> /dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' 2> /dev/null)
+PACKER_ZIP ?= https://releases.hashicorp.com/packer/$(PACKER_VERSION)/packer_$(PACKER_VERSION)_linux_amd64.zip
 PACKER_LOG ?= '1'
 PACKER_NO_COLOR ?= '1'
 CHECKPOINT_DISABLE ?= '1'

--- a/build/install.sh
+++ b/build/install.sh
@@ -5,6 +5,7 @@ apt -y install unzip
 echo "Installing packer..."
 echo "$PWD"
 curl -L "$PACKER_ZIP" -o packer.zip && unzip packer.zip
+./packer version
 
 # Check if $SPEL_ACCESS_KEY is not empty
 if [ -n "$SPEL_ACCESS_KEY" ]; then


### PR DESCRIPTION
With this patch, when hashicorp publishes a new packer version to dockerhub, dependabot will open a pr to update the Dockerfile. Mergify will then comment to kick off a build, and our github-codebuild integration will post the success/failed status back to the pr.

This is intentionally using a backrev version of packer in the Dockerfile, 1.6.5, so we'll see this in action the day after it is merged.

* New PR Alert to: @plus3it/spel
