### PR TITLE
Releases spel 2021.07.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2021.06.1
+current_version = 2021.07.1
 commit = False
 tag = False
 tag_name = {new_version}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,28 @@
 ## Changelog
 
+### 2021.07.1
+
+**Released**: 2021.07.21
+
+**Commit Delta**: [Change from 2021.06.1 release](https://github.com/plus3it/spel/compare/2021.06.1...2021.07.1)
+
+**Manifests**: <https://github.com/plus3it/spel/blob/2021.07.1/manifests>
+
+**Summary**:
+
+*   aws-cli v1 is now installed using python3
+*   "Extra" packages updated in this release:
+    - RHEL7: aws-cli/1.20.4
+    - CentOS7: aws-cli/1.20.3
+    - aws-cli/2.2.21
+
 ### 2021.06.1
 
 **Released**: 2021.06.22
 
 **Commit Delta**: [Change from 2021.05.1 release](https://github.com/plus3it/spel/compare/2021.05.1...2021.06.1)
 
-**Manifests**: <https://github.com/plus3it/spel/blob/2021.05.1/manifests>
+**Manifests**: <https://github.com/plus3it/spel/blob/2021.06.1/manifests>
 
 **Summary**:
 

--- a/manifests/spel-minimal-centos-7-hvm.manifest.txt
+++ b/manifests/spel-minimal-centos-7-hvm.manifest.txt
@@ -1,6 +1,6 @@
 CentOS Linux release 7.9.2009 (Core)
-aws-cli/1.19.98 Python/2.7.5 Linux/3.10.0-1062.1.2.el7.x86_64 botocore/1.20.98
-aws-cli/2.2.13 Python/3.8.8 Linux/3.10.0-1062.1.2.el7.x86_64 exe/x86_64.centos.7 prompt/off
+aws-cli/1.20.3 Python/3.6.8 Linux/3.10.0-1160.31.1.el7.x86_64 botocore/1.21.3
+aws-cli/2.2.21 Python/3.8.8 Linux/3.10.0-1160.31.1.el7.x86_64 exe/x86_64.centos.7 prompt/off
 acl-2.2.51-15.el7.x86_64
 acpid-2.0.19-9.el7.x86_64
 alsa-lib-1.1.8-1.el7.x86_64

--- a/manifests/spel-minimal-rhel-7-hvm.manifest.txt
+++ b/manifests/spel-minimal-rhel-7-hvm.manifest.txt
@@ -1,6 +1,6 @@
 Red Hat Enterprise Linux Server release 7.9 (Maipo)
-aws-cli/1.19.98 Python/2.7.5 Linux/3.10.0-1062.4.3.el7.x86_64 botocore/1.20.98
-aws-cli/2.2.13 Python/3.8.8 Linux/3.10.0-1062.4.3.el7.x86_64 exe/x86_64.rhel.7 prompt/off
+aws-cli/1.20.4 Python/3.6.8 Linux/3.10.0-1062.4.3.el7.x86_64 botocore/1.21.4
+aws-cli/2.2.21 Python/3.8.8 Linux/3.10.0-1062.4.3.el7.x86_64 exe/x86_64.rhel.7 prompt/off
 acl-2.2.51-15.el7.x86_64
 acpid-2.0.19-9.el7.x86_64
 alsa-lib-1.1.8-1.el7.x86_64
@@ -39,7 +39,7 @@ cairo-1.15.12-4.el7.x86_64
 checkpolicy-2.5-8.el7.x86_64
 chkconfig-1.7.6-1.el7.x86_64
 chrony-3.4-1.el7.x86_64
-cloud-init-19.4-7.el7_9.4.x86_64
+cloud-init-19.4-7.el7_9.5.x86_64
 cloud-utils-growpart-0.29-5.el7.noarch
 copy-jdk-configs-3.3-10.el7_5.noarch
 coreutils-8.22-24.el7_9.2.x86_64
@@ -160,9 +160,9 @@ json-c-0.11-4.el7_0.x86_64
 kbd-1.15.5-15.el7.x86_64
 kbd-legacy-1.15.5-15.el7.noarch
 kbd-misc-1.15.5-15.el7.noarch
-kernel-3.10.0-1160.31.1.el7.x86_64
-kernel-tools-3.10.0-1160.31.1.el7.x86_64
-kernel-tools-libs-3.10.0-1160.31.1.el7.x86_64
+kernel-3.10.0-1160.36.2.el7.x86_64
+kernel-tools-3.10.0-1160.36.2.el7.x86_64
+kernel-tools-libs-3.10.0-1160.36.2.el7.x86_64
 kexec-tools-2.0.15-51.el7_9.3.x86_64
 keyutils-1.5.8-3.el7.x86_64
 keyutils-libs-1.5.8-3.el7.x86_64
@@ -298,7 +298,7 @@ NetworkManager-team-1.18.8-2.el7_9.x86_64
 NetworkManager-tui-1.18.8-2.el7_9.x86_64
 newt-0.52.15-4.el7.x86_64
 newt-python-0.52.15-4.el7.x86_64
-nfs-utils-1.3.0-0.68.el7.x86_64
+nfs-utils-1.3.0-0.68.el7.1.x86_64
 nspr-4.25.0-2.el7_9.x86_64
 nss-3.53.1-7.el7_9.x86_64
 nss-pem-1.0.3-7.el7.x86_64
@@ -444,7 +444,7 @@ python-linux-procfs-0.4.11-4.el7.noarch
 python-lxml-3.2.1-4.el7.x86_64
 python-magic-5.11-37.el7.noarch
 python-markupsafe-0.11-10.el7.x86_64
-python-perf-3.10.0-1160.31.1.el7.x86_64
+python-perf-3.10.0-1160.36.2.el7.x86_64
 python-prettytable-0.7.2-3.el7.noarch
 python-pycurl-7.19.0-19.el7.x86_64
 python-pyudev-0.15-9.el7.noarch


### PR DESCRIPTION
Vagrant box was built, but no changes in the package manifest... Centos7 also had minimal changes, just the aws-cli version.

* New PR Alert to: @plus3it/spel
