### PR TITLE
Increases max_retries for aws builders to workaround rate limit errors

### DIFF
--- a/spel/minimal-linux.json
+++ b/spel/minimal-linux.json
@@ -45,6 +45,7 @@
                     "volume_type": "gp2"
                 }
             ],
+            "max_retries": 20,
             "name": "minimal-centos-7-hvm",
             "region": "{{ user `aws_region` }}",
             "source_ami": "{{ user `source_ami_centos7_hvm` }}",
@@ -78,6 +79,7 @@
                     "volume_type": "gp2"
                 }
             ],
+            "max_retries": 20,
             "name": "minimal-rhel-7-hvm",
             "region": "{{ user `aws_region` }}",
             "source_ami": "{{ user `source_ami_rhel7_hvm` }}",
@@ -166,6 +168,7 @@
                     "volume_type": "gp2"
                 }
             ],
+            "max_retries": 20,
             "name": "minimal-centos-8-hvm",
             "region": "{{ user `aws_region` }}",
             "source_ami": "{{ user `source_ami_centos8_hvm` }}",
@@ -199,6 +202,7 @@
                     "volume_type": "gp2"
                 }
             ],
+            "max_retries": 20,
             "name": "minimal-rhel-8-hvm",
             "region": "{{ user `aws_region` }}",
             "source_ami": "{{ user `source_ami_rhel8_hvm` }}",

--- a/tests/minimal-linux.json
+++ b/tests/minimal-linux.json
@@ -15,6 +15,7 @@
                     "volume_type": "gp2"
                 }
             ],
+            "max_retries": 20,
             "name": "minimal-centos-7-hvm",
             "region": "{{ user `aws_region` }}",
             "skip_save_build_region": "true",
@@ -43,6 +44,7 @@
                     "volume_type": "gp2"
                 }
             ],
+            "max_retries": 20,
             "name": "minimal-rhel-7-hvm",
             "region": "{{ user `aws_region` }}",
             "skip_save_build_region": "true",
@@ -71,6 +73,7 @@
                     "volume_type": "gp2"
                 }
             ],
+            "max_retries": 20,
             "name": "minimal-centos-8-hvm",
             "region": "{{ user `aws_region` }}",
             "skip_save_build_region": "true",
@@ -99,6 +102,7 @@
                     "volume_type": "gp2"
                 }
             ],
+            "max_retries": 20,
             "name": "minimal-rhel-8-hvm",
             "region": "{{ user `aws_region` }}",
             "skip_save_build_region": "true",


### PR DESCRIPTION
Packer defaults to 10 retries, but when the account is being rate-limited
that is often not enough. This most often appears to happen when querying
for the AMI id.
