### PR TITLE
Add Note About Possible (CONUS) commercial vs GovCloud Regions' Version-Deltas

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ directory.
 
 **Please note:** the RPM-manifests published to this directory are generated
 for the AWS (CONUS) commercial regions. Due to potential deltas between the
-repositositories used for the commercial and govcloud regions, there _may_ also
+repositories used for the commercial and govcloud regions, there _may_ also
 exist deltas between what is found in the manifests in this project and the
 version-numbers found in the GovCloud region AMIs.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ recent AMI of each build will be at the top when viewed in the AWS Console.
 RPM Manifests for published images are available in the [manifests](manifests)
 directory.
 
+**Please note:** the RPM-manifests published to this directory are generated
+for the AWS (CONUS) commercial regions. Due to potential deltas between the
+repositositories used for the commercial and govcloud regions, there _may_ also
+exist deltas between what is found in the manifests in this project and the
+version-numbers found in the GovCloud region AMIs.
+
 | AWS Region    | Builder Name / Link                     |
 |---------------|-----------------------------------------|
 | us-east-1     | [spel-minimal-rhel-7-hvm][1000]         |


### PR DESCRIPTION
It was decided to add this note to provide clarity for GovCloud users that might experience unexpected version-number differences between what's found in this project's manifest files and what might actually appear in an AMI generated in the GovCloud region for the same AMI release-ID (as originally reported in #621).

Closes #623
