### PR TITLE
Update automation-content to account for deltas in (vendor-furnished) OL9 bootstrap images

### DIFF
--- a/spel/scripts/amigen9-build.sh
+++ b/spel/scripts/amigen9-build.sh
@@ -36,7 +36,7 @@ HTTP_PROXY="${SPEL_HTTP_PROXY}"
 USEDEFAULTREPOS="${SPEL_USEDEFAULTREPOS:-true}"
 
 
-read -r -a BUILDDEPS <<< "${SPEL_BUILDDEPS:-lvm2 yum-utils unzip git}"
+read -r -a BUILDDEPS <<< "${SPEL_BUILDDEPS:-lvm2 yum-utils unzip git dosfstools python3-pip}"
 
 ELBUILD="/tmp/el-build"
 
@@ -96,7 +96,7 @@ case $( rpm -qf /etc/os-release --qf '%{name}' ) in
         BUILDER=ol-9
 
         DEFAULTREPOS=(
-            ol9_UEKR6
+            ol9_UEKR7
             ol9_appstream
             ol9_baseos_latest
         )

--- a/spel/scripts/builder-prep-9.sh
+++ b/spel/scripts/builder-prep-9.sh
@@ -14,7 +14,7 @@ HTTP_PROXY="${SPEL_HTTP_PROXY}"
 USEDEFAULTREPOS="${SPEL_USEDEFAULTREPOS:-true}"
 
 
-read -r -a BUILDDEPS <<< "${SPEL_BUILDDEPS:-lvm2 yum-utils unzip git}"
+read -r -a BUILDDEPS <<< "${SPEL_BUILDDEPS:-lvm2 yum-utils unzip git dosfstools python3-pip}"
 
 ELBUILD="/tmp/el-build"
 
@@ -74,7 +74,7 @@ case $( rpm -qf /etc/os-release --qf '%{name}' ) in
         BUILDER=ol-9
 
         DEFAULTREPOS=(
-            ol9_UEKR6
+            ol9_UEKR7
             ol9_appstream
             ol9_baseos_latest
         )

--- a/tests/minimal-linux.pkr.hcl
+++ b/tests/minimal-linux.pkr.hcl
@@ -18,6 +18,11 @@ variable "aws_source_ami_ol_8_hvm" {
   default = env("amazon_ebs_minimal_ol_8_hvm")
 }
 
+variable "aws_source_ami_ol_9_hvm" {
+  type    = string
+  default = env("amazon_ebs_minimal_ol_9_hvm")
+}
+
 variable "aws_source_ami_rhel7_hvm" {
   type    = string
   default = env("amazon_ebs_minimal_rhel_7_hvm")
@@ -116,6 +121,11 @@ build {
   source "amazon-ebs.base" {
     source_ami = var.aws_source_ami_ol_8_hvm
     name       = "minimal-ol-8-hvm"
+  }
+
+  source "amazon-ebs.base" {
+    source_ami = var.aws_source_ami_ol_9_hvm
+    name       = "minimal-ol-9-hvm"
   }
 
   source "amazon-ebs.base" {


### PR DESCRIPTION
Updates the `spel/scripts/amigen9-build.sh` and `spel/scripts/builder-prep-9.sh` files:

* Ensure that repo-references are correct: Change `ol9_UEKR6` to `ol9_UEKR7`
* Ensure that `SPEL_BUILDDEPS` variable _also_ contains the `dosfstools` and `python3-pip` RPMs