### PR TITLE
Update automation-content to account for deltas in (vendor-furnished) CentOS 9 Stream bootstrap images

### DIFF
--- a/spel/scripts/amigen9-build.sh
+++ b/spel/scripts/amigen9-build.sh
@@ -80,7 +80,7 @@ case $( rpm -qf /etc/os-release --qf '%{name}' ) in
         DEFAULTREPOS=(
             baseos
             appstream
-            extras
+            extras-common
         )
         ;;
     redhat-release-server|redhat-release)

--- a/spel/scripts/builder-prep-9.sh
+++ b/spel/scripts/builder-prep-9.sh
@@ -58,7 +58,7 @@ case $( rpm -qf /etc/os-release --qf '%{name}' ) in
         DEFAULTREPOS=(
             baseos
             appstream
-            extras
+            extras-common
         )
         ;;
     redhat-release-server|redhat-release)

--- a/tests/minimal-linux.pkr.hcl
+++ b/tests/minimal-linux.pkr.hcl
@@ -13,6 +13,11 @@ variable "aws_source_ami_centos8stream_hvm" {
   default = env("amazon_ebs_minimal_centos_8stream_hvm")
 }
 
+variable "aws_source_ami_centos9stream_hvm" {
+  type    = string
+  default = env("amazon_ebs_minimal_centos_9stream_hvm")
+}
+
 variable "aws_source_ami_ol_8_hvm" {
   type    = string
   default = env("amazon_ebs_minimal_ol_8_hvm")
@@ -111,6 +116,11 @@ build {
   source "amazon-ebs.base" {
     source_ami = var.aws_source_ami_centos8stream_hvm
     name       = "minimal-centos-8stream-hvm"
+  }
+
+  source "amazon-ebs.base" {
+    source_ami = var.aws_source_ami_centos9stream_hvm
+    name       = "minimal-centos-9stream-hvm"
   }
 
   source "amazon-ebs.base" {


### PR DESCRIPTION
1. Updates `spel/scripts/amigen9-build.sh` and `spel/scripts/builder-prep-9.sh` to reflect correct, default repo-names.
1. Adds/corrects builder test-definitions