### PR TITLE
Tweak `free-root.sh` script

### DIFF
--- a/spel/scripts/free-root.sh
+++ b/spel/scripts/free-root.sh
@@ -34,5 +34,12 @@ done
 echo "Sleeping to allow everything to stop"
 sleep 10
 
-echo Killing processes locking /oldroot
-fuser -vmk /oldroot
+if [[ $( mountpoint -q /oldroot )$? -eq 0 ]]
+then
+  echo "Killing processes locking /oldroot"
+  fuser -vmk /oldroot
+else
+  echo "NO-OP: /oldroot is not a mount"
+fi
+
+


### PR DESCRIPTION
Ensures that `fuser -vmk` is only run if `/oldroot`  is _actually_ a mounted filesystem.