### PR TITLE
Prevent Curve 25519 from being attempted for SSH comms

### DIFF
--- a/spel/minimal-linux.pkr.hcl
+++ b/spel/minimal-linux.pkr.hcl
@@ -804,22 +804,22 @@ source "amazon-ebs" "base" {
     volume_size           = var.spel_root_volume_size
     volume_type           = "gp3"
   }
-  max_retries                           = 20
-  region                                = var.aws_region
-  sriov_support                         = true
-  ssh_interface                         = var.aws_ssh_interface
-  ssh_port                              = 22
-  ssh_pty                               = true
-  ssh_timeout                           = "60m"
-  ssh_username                          = var.spel_ssh_username
-  ssh_key_exchange_algorithms           = [
-                                            "ecdh-sha2-nistp521",
-                                            "ecdh-sha2-nistp256",
-                                            "ecdh-sha2-nistp384",
-                                            "ecdh-sha2-nistp521",
-                                            "diffie-hellman-group14-sha1",
-                                            "diffie-hellman-group1-sha1"
-                                          ]
+  max_retries   = 20
+  region        = var.aws_region
+  sriov_support = true
+  ssh_interface = var.aws_ssh_interface
+  ssh_port      = 22
+  ssh_pty       = true
+  ssh_timeout   = "60m"
+  ssh_username  = var.spel_ssh_username
+  ssh_key_exchange_algorithms = [
+    "ecdh-sha2-nistp521",
+    "ecdh-sha2-nistp256",
+    "ecdh-sha2-nistp384",
+    "ecdh-sha2-nistp521",
+    "diffie-hellman-group14-sha1",
+    "diffie-hellman-group1-sha1"
+  ]
   subnet_id                             = var.aws_subnet_id
   tags                                  = { Name = "" } # Empty name tag avoids inheriting "Packer Builder"
   temporary_security_group_source_cidrs = var.aws_temporary_security_group_source_cidrs

--- a/spel/minimal-linux.pkr.hcl
+++ b/spel/minimal-linux.pkr.hcl
@@ -812,6 +812,14 @@ source "amazon-ebs" "base" {
   ssh_pty                               = true
   ssh_timeout                           = "60m"
   ssh_username                          = var.spel_ssh_username
+  ssh_key_exchange_algorithms           = [
+                                            "ecdh-sha2-nistp521",
+                                            "ecdh-sha2-nistp256",
+                                            "ecdh-sha2-nistp384",
+                                            "ecdh-sha2-nistp521",
+                                            "diffie-hellman-group14-sha1",
+                                            "diffie-hellman-group1-sha1"
+                                          ]
   subnet_id                             = var.aws_subnet_id
   tags                                  = { Name = "" } # Empty name tag avoids inheriting "Packer Builder"
   temporary_security_group_source_cidrs = var.aws_temporary_security_group_source_cidrs


### PR DESCRIPTION
Closes #680

Validated that proposed change allows OL9 to work while continuing to allowi OL8 (and presumably RHEL8 and COS8)  and CO7 (and presumably RHEL7) to work.

* New PR Alert to: @plus3it/spel
