### PR TITLE
Add logic to make things less AWS-only

### DIFF
--- a/spel/scripts/amigen8-build.sh
+++ b/spel/scripts/amigen8-build.sh
@@ -557,25 +557,30 @@ function PrepBuildDevice {
     local ROOT_DISK
     local DISKS
 
-    # Select the disk to use for the build
-    err_exit "Detecting the root device..." NONE
-    ROOT_DEV="$( grep ' / ' /proc/mounts | cut -d " " -f 1 )"
-    if [[ ${ROOT_DEV} == /dev/nvme* ]]
+    if [[ -n ${SPEL_AMIGENBUILDDEV:-} ]]
     then
-      ROOT_DISK="${ROOT_DEV//p*/}"
-      IFS=" " read -r -a DISKS <<< "$(echo /dev/nvme*n1)"
+      AMIGENBUILDDEV="${SPEL_AMIGENBUILDDEV}"
     else
-      err_exit "ERROR: This script supports nvme device naming. Could not determine root disk from device name: ${ROOT_DEV}"
-    fi
+      # Select the disk to use for the build
+      err_exit "Detecting the root device..." NONE
+      ROOT_DEV="$( grep ' / ' /proc/mounts | cut -d " " -f 1 )"
+      if [[ ${ROOT_DEV} == /dev/nvme* ]]
+      then
+        ROOT_DISK="${ROOT_DEV//p*/}"
+        IFS=" " read -r -a DISKS <<< "$(echo /dev/nvme*n1)"
+      else
+        err_exit "ERROR: This script supports nvme device naming. Could not determine root disk from device name: ${ROOT_DEV}"
+      fi
 
-    if [[ "$USEROOTDEVICE" = "true" ]]
-    then
-      AMIGENBUILDDEV="${ROOT_DISK}"
-    elif [[ ${#DISKS[@]} -gt 2 ]]
-    then
-      err_exit "ERROR: This script supports at most 2 attached disks. Detected ${#DISKS[*]} disks"
-    else
-      AMIGENBUILDDEV="$(echo "${DISKS[@]/$ROOT_DISK}" | tr -d '[:space:]')"
+      if [[ "$USEROOTDEVICE" = "true" ]]
+      then
+        AMIGENBUILDDEV="${ROOT_DISK}"
+      elif [[ ${#DISKS[@]} -gt 2 ]]
+      then
+        err_exit "ERROR: This script supports at most 2 attached disks. Detected ${#DISKS[*]} disks"
+      else
+        AMIGENBUILDDEV="$(echo "${DISKS[@]/$ROOT_DISK}" | tr -d '[:space:]')"
+      fi
     fi
     err_exit "Using ${AMIGENBUILDDEV} as the build device." NONE
 


### PR DESCRIPTION
Fixes #740 (for EL8, only)

Adds branch-logic  to the `spel/scripts/amigen8-build.sh` script to allow avoiding execution of code-segment that breaks builds for Azure

* New PR Alert to: @plus3it/spel
