### PR TITLE
Add Azure-specifi /efi mount-point

### DIFF
--- a/spel/scripts/pivot-root.sh
+++ b/spel/scripts/pivot-root.sh
@@ -15,7 +15,7 @@ echo "Installing psmisc RPM..."
 yum -y install psmisc
 
 # Get rid of anything that might be in the /boot hierarchy
-for BOOT_DIR in /boot{/efi,}
+for BOOT_DIR in /boot{/efi,} /efi
 do
   if  [[ -d ${BOOT_DIR} ]] &&
       [[ $( mountpoint "${BOOT_DIR}" ) == "${BOOT_DIR} is a mountpoint" ]]


### PR DESCRIPTION
Discovered that Azure-hosted RHEL VM-templates published by Red Hat have one disk-slice double-mounted with (typically) /dev/sda2 being mounted as both /boot/efi and /efi. This _may_ be contributing to the issues observed with RHEL 9 bootstrapping efforts failing when attempting to release the boot-disk's /-hosting partition


Fixes #754.

Changes offered/proposed in this pull request:
- Updates boot-devs iteration to include the (Azure-specific) `/efi` mount

* New PR Alert to: @plus3it/spel
