### PR TITLE
Adds builder for Rocky Linux 9

### DIFF
--- a/spel/minimal-linux.pkr.hcl
+++ b/spel/minimal-linux.pkr.hcl
@@ -187,6 +187,22 @@ variable "aws_source_ami_filter_rhel9_hvm" {
   }
 }
 
+variable "aws_source_ami_filter_rl9_hvm" {
+  description = "Object with source AMI filters for Rocky Linux 9 HVM builds"
+  type = object({
+    name   = string
+    owners = list(string)
+  })
+  default = {
+    name = "Rocky-9-EC2-Base-9.*-*.x86_64,spel-bootstrap-rl-9-*.x86_64-gp*"
+    owners = [
+      "792107900819", # Rocky Linux, https://rockylinux.org/download (search for "AWS" tag and click)
+      "174003430611", # SPEL Commercial, https://github.com/plus3it/spel
+      "216406534498", # SPEL GovCloud, https://github.com/plus3it/spel
+    ]
+  }
+}
+
 variable "aws_ssh_interface" {
   description = "Specifies method used to select the value for the host in the SSH connection"
   type        = string
@@ -922,6 +938,20 @@ build {
     }
   }
 
+  source "amazon-ebssurrogate.base" {
+    ami_description = format(local.description, "Rocky Linux 9 AMI")
+    name            = "minimal-rl-9-hvm"
+    source_ami_filter {
+      filters = {
+        virtualization-type = "hvm"
+        name                = var.aws_source_ami_filter_rl9_hvm.name
+        root-device-type    = "ebs"
+      }
+      owners      = var.aws_source_ami_filter_rl9_hvm.owners
+      most_recent = true
+    }
+  }
+
   source "azure-arm.base" {
     azure_tags = {
       Description = format(local.description, "RHEL 8 image")
@@ -965,6 +995,7 @@ build {
       "amazon-ebssurrogate.minimal-centos-9stream-hvm",
       "amazon-ebssurrogate.minimal-ol-9-hvm",
       "amazon-ebssurrogate.minimal-rhel-9-hvm",
+      "amazon-ebssurrogate.minimal-rl-9-hvm",
     ]
   }
 
@@ -1101,6 +1132,7 @@ build {
       "amazon-ebssurrogate.minimal-centos-9stream-hvm",
       "amazon-ebssurrogate.minimal-ol-9-hvm",
       "amazon-ebssurrogate.minimal-rhel-9-hvm",
+      "amazon-ebssurrogate.minimal-rl-9-hvm",
     ]
     scripts = [
       "${path.root}/scripts/amigen9-build.sh",

--- a/spel/scripts/amigen9-build.sh
+++ b/spel/scripts/amigen9-build.sh
@@ -100,6 +100,16 @@ case $( rpm -qf /etc/os-release --qf '%{name}' ) in
             rhui-client-config-server-9
         )
         ;;
+    rocky-release)
+        BUILDER=rl-9
+
+        DEFAULTREPOS=(
+            baseos
+            appstream
+            extras
+         )
+        ;;
+
     system-release) # Amazon should be shot for this
         BUILDER=amzn-2023
 

--- a/spel/scripts/builder-prep-9.sh
+++ b/spel/scripts/builder-prep-9.sh
@@ -61,6 +61,15 @@ case $( rpm -qf /etc/os-release --qf '%{name}' ) in
             extras-common
         )
         ;;
+    oraclelinux-release)
+        BUILDER=ol-9
+
+        DEFAULTREPOS=(
+            ol9_UEKR7
+            ol9_appstream
+            ol9_baseos_latest
+        )
+        ;;
     redhat-release-server|redhat-release)
         BUILDER=rhel-9
 
@@ -70,13 +79,12 @@ case $( rpm -qf /etc/os-release --qf '%{name}' ) in
             rhui-client-config-server-9
         )
         ;;
-    oraclelinux-release)
-        BUILDER=ol-9
-
+    rocky-release)
+        BUILDER=rl-9
         DEFAULTREPOS=(
-            ol9_UEKR7
-            ol9_appstream
-            ol9_baseos_latest
+            baseos
+            appstream
+            extras
         )
         ;;
     system-release) # Amazon should be shot for this

--- a/spel/userdata/userdata.cloud
+++ b/spel/userdata/userdata.cloud
@@ -13,3 +13,7 @@ user:
 runcmd:
   # use default crypto policies, if possible
   - update-crypto-policies --set DEFAULT || true
+  # Disable IPv6
+  - /usr/sbin/sysctl -w net.ipv6.conf.all.disable_ipv6=1
+  - /usr/sbin/sysctl -w net.ipv6.conf.default.disable_ipv6=1
+  - /usr/sbin/sysctl -w net.ipv6.conf.lo.disable_ipv6=1


### PR DESCRIPTION
Fixes #757

Am able to build images in AWS (CONUS) commercial regions using the images published by rockylinux.org as bootstraps. No equivalent (free) images exist in GovCloud region. Will need to create those to fully finish out this task.